### PR TITLE
Lowers the price of rocket launcher ammo.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -884,14 +884,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "84mm HE Rocket"
 	desc = "A low-yield anti-personnel HE rocket. Gonna take you out in style!"
 	item = /obj/item/ammo_casing/caseless/rocket
-	cost = 4
+	cost = 2
 
 /datum/uplink_item/ammo/rocket/hedp
 	name = "84mm HEDP Rocket"
 	desc = "A high-yield HEDP rocket; extremely effective against armored targets, as well as surrounding personnel. \
 			Strike fear into the hearts of your enemies."
 	item = /obj/item/ammo_casing/caseless/rocket/hedp
-	cost = 6
+	cost = 3
 
 /datum/uplink_item/ammo/rocket/solidfuel
 	name = "84mm Solid Fuel Canister"


### PR DESCRIPTION
**Cuts the price of PML-9 ammo in half!**
 - the HE rocket went from 4 to 2 TC
 - the HEDP rocket went from 6 to 3 TC

The PML-9 is just like some other nukie weapons, overshadowed by the better options such as the L6 or M90-GL.
This is mainly because of the fact that the L6 and M90 are capable of quickly and effortlessly killing people, whereas the PML-9 has several dangers tied to it while being very ammo-inefficient.

This change aims to make the PML-9 a more relevant nukie weapon, so operatives who like explosives won't shy away from it due to better options being available while the crew gets to see more variety in operatives.

:cl:
balance: PML-9 rocket prices are cut in half due to the supply far exeeding its demand...
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
