### PR TITLE
Add circuit mechs

### DIFF
--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -322,6 +322,18 @@
 	build_type = PROTOLATHE | COMPONENT_PRINTER
 	category = list("Circuitry", "Shells")
 
+/datum/design/mech_shell
+	name = "Mech Interface Assembly"
+	desc = "A shell assembly that can permanently convert any mech into a circuit mech."
+	id = "mech_shell"
+	materials = list(
+		/datum/material/glass = 2000,
+		/datum/material/iron = 6000,
+	)
+	build_path = /obj/item/shell/mech
+	build_type = PROTOLATHE | COMPONENT_PRINTER
+	category = list("Circuitry", "Shells")
+
 /datum/design/bci_shell
 	name = "Brain-Computer Interface Shell"
 	desc = "An implant that can be placed in a user's head to control circuits using their brain."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -664,6 +664,7 @@
 		"bci_implanter",
 		"bci_shell",
 		"bot_shell",
+		"mech_shell",
 		"door_shell",
 		"controller_shell",
 		"money_bot_shell",

--- a/code/modules/wiremod/shell/mech.dm
+++ b/code/modules/wiremod/shell/mech.dm
@@ -1,0 +1,144 @@
+/obj/item/circuit_component/mech_movement
+	display_name = "Mech Movement"
+	display_desc = "The movement interface with an mech."
+
+	/// Called when attack_hand is called on the shell.
+	var/obj/vehicle/sealed/mecha/attached_mech
+
+	/// The inputs to allow for the drone to move
+	var/datum/port/input/north
+	var/datum/port/input/east
+	var/datum/port/input/south
+	var/datum/port/input/west
+
+	// Done like this so that travelling diagonally is more simple
+	COOLDOWN_DECLARE(north_delay)
+	COOLDOWN_DECLARE(east_delay)
+	COOLDOWN_DECLARE(south_delay)
+	COOLDOWN_DECLARE(west_delay)
+
+	/// Delay between each movement
+	var/move_delay = 0.1 SECONDS
+
+/obj/item/circuit_component/mech_movement/Initialize()
+	. = ..()
+	north = add_input_port("Move North", PORT_TYPE_SIGNAL)
+	east = add_input_port("Move East", PORT_TYPE_SIGNAL)
+	south = add_input_port("Move South", PORT_TYPE_SIGNAL)
+	west = add_input_port("Move West", PORT_TYPE_SIGNAL)
+
+
+/obj/item/circuit_component/mech_movement/register_shell(atom/movable/shell)
+	. = ..()
+	if(istype(shell, /obj/vehicle/sealed/mecha))
+		attached_mech = shell
+
+/obj/item/circuit_component/mech_movement/Destroy()
+	north = null
+	east = null
+	south = null
+	west = null
+	return ..()
+
+/obj/item/circuit_component/mech_movement/input_received(datum/port/input/port)
+	. = ..()
+	if(.)
+		return
+
+	if(!attached_mech)
+		return
+
+	var/direction
+
+	if(COMPONENT_TRIGGERED_BY(north, port) && COOLDOWN_FINISHED(src, north_delay))
+		direction = NORTH
+		COOLDOWN_START(src, north_delay, move_delay)
+	else if(COMPONENT_TRIGGERED_BY(east, port) && COOLDOWN_FINISHED(src, east_delay))
+		direction = EAST
+		COOLDOWN_START(src, east_delay, move_delay)
+	else if(COMPONENT_TRIGGERED_BY(south, port) && COOLDOWN_FINISHED(src, south_delay))
+		direction = SOUTH
+		COOLDOWN_START(src, south_delay, move_delay)
+	else if(COMPONENT_TRIGGERED_BY(west, port) && COOLDOWN_FINISHED(src, west_delay))
+		direction = WEST
+		COOLDOWN_START(src, west_delay, move_delay)
+
+	if(!direction)
+		return
+
+	attached_mech.vehicle_move(direction)
+
+/obj/item/circuit_component/mech_equipment
+	display_name = "Mech Equipment"
+	display_desc = "The equipment interface with an mech."
+
+	/// Called when attack_hand is called on the shell.
+	var/obj/vehicle/sealed/mecha/combat/attached_mech
+
+	/// The inputs to allow for the drone to move
+	var/datum/port/input/attack
+	var/datum/port/input/target
+	var/datum/port/input/change_equipment
+	var/mob/living/attacker = null
+
+
+/obj/item/circuit_component/mech_equipment/Initialize()
+	. = ..()
+	attack = add_input_port("Attack", PORT_TYPE_SIGNAL)
+	target = add_input_port("Target", PORT_TYPE_ATOM)
+	change_equipment = add_input_port("Switch Equipment", PORT_TYPE_SIGNAL)
+
+	attacker = new
+	attacker.combat_mode = TRUE
+
+
+/obj/item/circuit_component/mech_equipment/register_shell(atom/movable/shell)
+	. = ..()
+	if(istype(shell, /obj/vehicle/sealed/mecha))
+		attached_mech = shell
+		attached_mech.add_occupant(attacker, VEHICLE_CONTROL_EQUIPMENT | VEHICLE_CONTROL_MELEE)
+
+/obj/item/circuit_component/mech_equipment/unregister_shell(atom/movable/shell)
+	attached_mech.remove_occupant(attacker)
+
+/obj/item/circuit_component/mech_equipment/Destroy()
+	attack = null
+	target = null
+	change_equipment = null
+	attached_mech.remove_occupant(attacker)
+	qdel(attacker)
+	return ..()
+
+/obj/item/circuit_component/mech_equipment/input_received(datum/port/input/port)
+	. = ..()
+	if(.)
+		return
+
+	if(!attached_mech)
+		return
+	if(COMPONENT_TRIGGERED_BY(attack, port))
+		var/atom/tgt = target.input_value
+		if(!tgt)
+			return
+		attached_mech.on_mouseclick(attacker, tgt, "")
+
+	if(COMPONENT_TRIGGERED_BY(change_equipment, port))
+		var/list/available_equipment = list()
+		for(var/e in attached_mech.equipment)
+			var/obj/item/mecha_parts/mecha_equipment/equipment = e
+			if(equipment.selectable)
+				available_equipment += equipment
+		if(!attached_mech.selected)
+			attached_mech.selected = available_equipment[1]
+			return
+		var/number = 0
+		for(var/equipment in available_equipment)
+			number++
+			if(equipment != attached_mech.selected)
+				continue
+			if(available_equipment.len == number)
+				attached_mech.selected = null
+			else
+				attached_mech.selected = available_equipment[number+1]
+			return
+	

--- a/code/modules/wiremod/shell/shell_items.dm
+++ b/code/modules/wiremod/shell/shell_items.dm
@@ -57,3 +57,39 @@
 	name = "brain-computer interface assembly"
 	icon_state = "bci-open"
 	shell_to_spawn = /obj/item/organ/cyberimp/bci
+
+/obj/item/shell/mech
+	name = "mech interface assembly"
+	icon_state = "bci-open"
+	desc = "A shell assembly that can permanently convert any mech into a circuit mech. It has a screw that just keeps turning in place. Odd."
+	shell_to_spawn = /obj/item/shell/mech
+
+/obj/item/shell/mech/afterattack(atom/target, mob/user, proximity)
+	if(!proximity)
+		return
+	if(!istype(target, /obj/vehicle/sealed/mecha))
+		return
+	var/datum/component/shell/shell_mech = target.GetComponent(/datum/component/shell)
+	if(shell_mech)
+		return
+	user.visible_message(span_notice("[user] begins inserting an interface module into [target]."), span_notice("You begin inserting the circuit interface into [target]."))
+	if(!do_after(user, 8 SECONDS, src))
+		return
+	user.visible_message(span_notice("[user] finishes inserting the mech interface module into [target]."), span_notice("You finish inserting the circuit interface into [target]."))
+	target.AddComponent( \
+		/datum/component/shell, \
+		unremovable_circuit_components = list(new /obj/item/circuit_component/mech_movement, new /obj/item/circuit_component/mech_equipment), \
+		capacity = SHELL_CAPACITY_LARGE, \
+		shell_flags = SHELL_FLAG_ALLOW_FAILURE_ACTION \
+	)
+	target.name += "-Circuitix"
+	qdel(src)
+
+
+/obj/item/shell/mech/screwdriver_act(mob/living/user, obj/item/tool)
+	user.visible_message(span_notice("[user] begins screwing [src]."), span_notice("You begin screwing [src]."))
+	tool.play_tool_sound(src)
+	if(!do_after(user, 1 SECONDS, src))
+		return
+	user.visible_message(span_notice("[user] rotates the screw of [src] in place."), span_notice("The screw just spins in place. Darn."))
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3745,6 +3745,7 @@
 #include "code\modules\wiremod\shell\compact_remote.dm"
 #include "code\modules\wiremod\shell\controller.dm"
 #include "code\modules\wiremod\shell\drone.dm"
+#include "code\modules\wiremod\shell\mech.dm"
 #include "code\modules\wiremod\shell\moneybot.dm"
 #include "code\modules\wiremod\shell\scanner.dm"
 #include "code\modules\wiremod\shell\server.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can turn any mech into a circuit mech using a researchable mech interface, printable at the protolathe or component printer.
Doing so is irreversible and takes 8 seconds. It also adds "-Circuitix" by default to the mech's name, though you can still change it by climbing in.
You can still use it as normal, but it can now be occupied by integrated circuits, which prevent you from entering them. You can screwdriver them out to be able to climb in again, of course.
The circuit placed inside a circuit mech can move it around, cycle equipment and use currently selected equipment to attack. It can't use radial menus or anything of course.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Because autonomous mechs are funny and balanced.

## Changelog
:cl:
add: All mechs can now be upgraded to be able to take a circuit as a controller/occupant. Nanotrasen has assured us that nothing bad can come out of the ability to autonomously pilot the deadliest vehicles available on the station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
