### PR TITLE
Adds the Explosives bundle (and a rocket ammo box) for nukies.

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -650,6 +650,18 @@
 	slowdown = 0
 	STR.silent = TRUE
 
+/obj/item/storage/backpack/duffelbag/syndie/demolitions
+	desc = "A large duffel bag containing a PML-9 Rocket Launcher, Grenadier's Belt, extra rockets and a label that reads; \"For you, Capitán!\""
+
+/obj/item/storage/backpack/duffelbag/syndie/demolitions/PopulateContents()
+	new /obj/item/gun/ballistic/rocketlauncher(src)
+	new /obj/item/storage/belt/grenade/full(src)
+	new /obj/item/storage/box/syndie_kit/rockets(src)
+	new /obj/item/clothing/glasses/orange(src)
+	new /obj/item/storage/fancy/cigarettes/cigars/havana(src)
+	new /obj/item/storage/box/matches(src)
+	new /obj/item/clothing/head/hos/syndicate(src)
+
 /obj/item/storage/backpack/duffelbag/clown/syndie/PopulateContents()
 	new /obj/item/pda/clown(src)
 	new /obj/item/clothing/under/rank/civilian/clown(src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -480,6 +480,21 @@
 	new /obj/item/reagent_containers/glass/bottle/amanitin(src)
 	new /obj/item/reagent_containers/syringe(src)
 
+/obj/item/storage/box/syndie_kit/rockets
+	name = "rocket box"
+
+/obj/item/storage/box/syndie_kit/rockets/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = 9
+
+/obj/item/storage/box/syndie_kit/rockets/PopulateContents()
+	new /obj/item/ammo_casing/caseless/rocket/hedp(src)
+	for(var/i in 1 to 6)
+		new /obj/item/ammo_casing/caseless/rocket(src)
+	for(var/i in 1 to 2)
+		new /obj/item/ammo_casing/caseless/rocket/solidfuel(src)
+
 /obj/item/storage/box/syndie_kit/nuke
 	name = "box"
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -203,6 +203,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 30
 	purchasable_from = UPLINK_NUKE_OPS
 
+/datum/uplink_item/bundles_tc/demolitions
+	name = "Explosives bundle"
+	desc = "For the demolitions expert: Contains a PML-9 Rocket Launcher, a filled Grenadier's Belt and a rocket ammunition box. \
+			Comes with extra havanian cigars, a matchbox, orange shades and a lovely military cap, courtesy of the Third Soviet Union."
+	item = /obj/item/storage/backpack/duffelbag/syndie/demolitions
+	cost = 35
+	purchasable_from = UPLINK_NUKE_OPS
+
 /datum/uplink_item/bundles_tc/contract_kit
 	name = "Contract Kit"
 	desc = "The Syndicate have offered you the chance to become a contractor, take on kidnapping contracts for TC and cash payouts. Upon purchase, \
@@ -899,6 +907,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	These canisters have been heavily modified to burn anything behind you much, much worse."
 	item = /obj/item/ammo_casing/caseless/rocket/solidfuel
 	cost = 1
+
+/datum/uplink_item/ammo/rocket/box
+	name = "84mm Rocket Ammunition Box"
+	desc = "This box of rockets contains six HE rockets, two solid fuel test firing canisters and a single HEDP rocket. \
+			The total price would be 17 TC, so don't ask questions about safety standards, it's a steal!"
+	item = /obj/item/storage/box/syndie_kit/rockets
+	cost = 14
 
 /datum/uplink_item/ammo/toydarts
 	name = "Box of Riot Darts"
@@ -1710,7 +1725,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	uplink_box.name = "Uplink Implant Box"
 	new /obj/item/implanter/uplink(uplink_box, purchaser_uplink.uplink_flag)
 	return uplink_box
-	
+
 
 /datum/uplink_item/implants/xray
 	name = "X-ray Vision Implant"


### PR DESCRIPTION
**Adds an explosives bundle for nuclear operatives, it contains:**
 - PML-9 Rocket Launcher
 - Grenadier's Belt
 - 84mm Rocket Ammunition Box
 - Havanian cigars, a matchbox, orange sunglasses and a syndie HoS cap.
 
 **Also adds a Rocket Ammunition Box, it contains:**
  - Six HE rockets
  - Two solid fuel canisters
  - One HEDP rocket
  
  This was done as a love letter to people who like explosives, giving them access to a fun bundle while also introducing the classic _Cuban dictator with a rocket launcher_ bad guy.