### PR TITLE
Converting Cultists to Low Pop

### DIFF
--- a/code/__DEFINES/cult.dm
+++ b/code/__DEFINES/cult.dm
@@ -10,24 +10,24 @@
 #define RUNE_COLOR_SUMMON "#00FF00"
 
 //blood magic
-#define MAX_BLOODCHARGE 4
+#define MAX_BLOODCHARGE 3
 #define RUNELESS_MAX_BLOODCHARGE 1
 /// percent before rise
 #define CULT_RISEN 0.2
 /// percent before ascend
-#define CULT_ASCENDENT 0.4
+#define CULT_ASCENDENT 0.3
 #define BLOOD_HALBERD_COST 150
 #define BLOOD_BARRAGE_COST 300
 #define BLOOD_BEAM_COST 500
-#define IRON_TO_CONSTRUCT_SHELL_CONVERSION 50
+#define IRON_TO_CONSTRUCT_SHELL_CONVERSION 25
 //screen locations
 #define DEFAULT_BLOODSPELLS "6:-29,4:-2"
 #define DEFAULT_BLOODTIP "14:6,14:27"
 #define DEFAULT_TOOLTIP "6:-29,5:-2"
 //misc
 #define SOULS_TO_REVIVE 3
-#define BLOODCULT_EYE "f00"
+#define BLOODCULT_EYE "#FF0000"
 //soulstone & construct themes
-#define THEME_CULT "cult" 
+#define THEME_CULT "cult"
 #define THEME_WIZARD "wizard"
 #define THEME_HOLY "holy"

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -794,15 +794,15 @@
 /obj/item/melee/blood_magic/manipulator/attack_self(mob/living/user)
 	if(IS_CULTIST(user))
 		var/static/list/spells = list(
-			"Bloody Halberd (" + BLOOD_HALBERD_COST + ")" = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "occultpoleaxe0"),
-			"Bloody Barrage (" + BLOOD_BARRAGE_COST + ")" = image(icon = 'icons/obj/guns/ballistic.dmi', icon_state = "arcane_barrage"),
-			"Bloody Beam (" + BLOOD_BEAM_COST + ")" = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "disintegrate")
+			"Bloody Halberd ( [BLOOD_HALBERD_COST] )" = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "occultpoleaxe0"),
+			"Bloody Barrage ( [BLOOD_BARRAGE_COST] )" = image(icon = 'icons/obj/guns/ballistic.dmi', icon_state = "arcane_barrage"),
+			"Bloody Beam ( [BLOOD_BEAM_COST] )" = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "disintegrate")
 			)
 		var/choice = show_radial_menu(user, src, spells, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE)
 		if(!check_menu(user))
 			to_chat(user, span_cultitalic("You decide against conducting a greater blood rite."))
 			return
-		if(choice == "Bloody Halberd (" + BLOOD_HALBERD_COST + ")")
+		if(choice == "Bloody Halberd ( [BLOOD_HALBERD_COST] )")
 			if(uses < BLOOD_HALBERD_COST)
 				to_chat(user, span_cultitalic("You need [BLOOD_HALBERD_COST] charges to perform this rite."))
 			else
@@ -818,7 +818,7 @@
 				else
 					user.visible_message(span_warning("A [rite.name] appears at [user]'s feet!"), \
 						span_cultitalic("A [rite.name] materializes at your feet."))
-		if(choice == "Bloody Barrage (" + BLOOD_BARRAGE_COST + ")")
+		if(choice == "Bloody Barrage ( [BLOOD_BARRAGE_COST] )")
 			if(uses < BLOOD_BARRAGE_COST)
 				to_chat(user, span_cultitalic("You need [BLOOD_BARRAGE_COST] charges to perform this rite."))
 			else
@@ -830,7 +830,7 @@
 				else
 					to_chat(user, span_cultitalic("You need a free hand for this rite!"))
 					qdel(rite)
-		if(choice == "Bloody Beam (" + BLOOD_BEAM_COST + ")")
+		if(choice == "Bloody Beam ( [BLOOD_BEAM_COST] )")
 			if(uses < BLOOD_BEAM_COST)
 				to_chat(user, span_cultitalic("You need [BLOOD_BEAM_COST] charges to perform this rite."))
 			else

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -443,14 +443,14 @@
 
 		else
 			to_chat(user, span_cultitalic("In a brilliant flash of red, [L] falls to the ground!"))
-			L.Paralyze(16 SECONDS)
+			L.Paralyze(6 SECONDS)
 			L.flash_act(1,TRUE)
 			if(issilicon(target))
 				var/mob/living/silicon/S = L
 				S.emp_act(EMP_HEAVY)
 			else if(iscarbon(target))
 				var/mob/living/carbon/C = L
-				C.silent += 6
+				C.silent += 3
 				C.stuttering += 15
 				C.cultslurring += 15
 				C.Jitter(1.5 SECONDS)
@@ -530,7 +530,7 @@
 			if(!C.handcuffed)
 				C.set_handcuffed(new /obj/item/restraints/handcuffs/energy/cult/used(C))
 				C.update_handcuffed()
-				C.silent += 5
+				C.silent += 2
 				to_chat(user, span_notice("You shackle [C]."))
 				log_combat(user, C, "shackled")
 				uses--
@@ -777,9 +777,9 @@
 		for(var/obj/effect/decal/cleanable/blood/B in view(T, 2))
 			if(B.blood_state == BLOOD_STATE_HUMAN)
 				if(B.bloodiness == 100) //Bonus for "pristine" bloodpools, also to prevent cheese with footprint spam
-					temp += 30
+					temp += 60
 				else
-					temp += max((B.bloodiness**2)/800,1)
+					temp += max((B.bloodiness**2)/400,1)
 				new /obj/effect/temp_visual/cult/turf/floor(get_turf(B))
 				qdel(B)
 		for(var/obj/effect/decal/cleanable/trail_holder/TH in view(T, 2))
@@ -794,55 +794,54 @@
 /obj/item/melee/blood_magic/manipulator/attack_self(mob/living/user)
 	if(IS_CULTIST(user))
 		var/static/list/spells = list(
-			"Bloody Halberd (150)" = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "occultpoleaxe0"),
-			"Blood Bolt Barrage (300)" = image(icon = 'icons/obj/guns/ballistic.dmi', icon_state = "arcane_barrage"),
-			"Blood Beam (500)" = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "disintegrate")
+			"Bloody Halberd (" + BLOOD_HALBERD_COST + ")" = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "occultpoleaxe0"),
+			"Bloody Barrage (" + BLOOD_BARRAGE_COST + ")" = image(icon = 'icons/obj/guns/ballistic.dmi', icon_state = "arcane_barrage"),
+			"Bloody Beam (" + BLOOD_BEAM_COST + ")" = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "disintegrate")
 			)
 		var/choice = show_radial_menu(user, src, spells, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE)
 		if(!check_menu(user))
 			to_chat(user, span_cultitalic("You decide against conducting a greater blood rite."))
 			return
-		switch(choice)
-			if("Bloody Halberd (150)")
-				if(uses < BLOOD_HALBERD_COST)
-					to_chat(user, span_cultitalic("You need [BLOOD_HALBERD_COST] charges to perform this rite."))
+		if(choice == "Bloody Halberd (" + BLOOD_HALBERD_COST + ")")
+			if(uses < BLOOD_HALBERD_COST)
+				to_chat(user, span_cultitalic("You need [BLOOD_HALBERD_COST] charges to perform this rite."))
+			else
+				uses -= BLOOD_HALBERD_COST
+				var/turf/current_position = get_turf(user)
+				qdel(src)
+				var/datum/action/innate/cult/halberd/halberd_act_granted = new(user)
+				var/obj/item/melee/cultblade/halberd/rite = new(current_position)
+				halberd_act_granted.Grant(user, rite)
+				rite.halberd_act = halberd_act_granted
+				if(user.put_in_hands(rite))
+					to_chat(user, span_cultitalic("A [rite.name] appears in your hand!"))
 				else
-					uses -= BLOOD_HALBERD_COST
-					var/turf/current_position = get_turf(user)
-					qdel(src)
-					var/datum/action/innate/cult/halberd/halberd_act_granted = new(user)
-					var/obj/item/melee/cultblade/halberd/rite = new(current_position)
-					halberd_act_granted.Grant(user, rite)
-					rite.halberd_act = halberd_act_granted
-					if(user.put_in_hands(rite))
-						to_chat(user, span_cultitalic("A [rite.name] appears in your hand!"))
-					else
-						user.visible_message(span_warning("A [rite.name] appears at [user]'s feet!"), \
-							span_cultitalic("A [rite.name] materializes at your feet."))
-			if("Blood Bolt Barrage (300)")
-				if(uses < BLOOD_BARRAGE_COST)
-					to_chat(user, span_cultitalic("You need [BLOOD_BARRAGE_COST] charges to perform this rite."))
+					user.visible_message(span_warning("A [rite.name] appears at [user]'s feet!"), \
+						span_cultitalic("A [rite.name] materializes at your feet."))
+		if(choice == "Bloody Barrage (" + BLOOD_BARRAGE_COST + ")")
+			if(uses < BLOOD_BARRAGE_COST)
+				to_chat(user, span_cultitalic("You need [BLOOD_BARRAGE_COST] charges to perform this rite."))
+			else
+				var/obj/rite = new /obj/item/gun/ballistic/rifle/enchanted/arcane_barrage/blood()
+				uses -= BLOOD_BARRAGE_COST
+				qdel(src)
+				if(user.put_in_hands(rite))
+					to_chat(user, span_cult("<b>Your hands glow with power!</b>"))
 				else
-					var/obj/rite = new /obj/item/gun/ballistic/rifle/enchanted/arcane_barrage/blood()
-					uses -= BLOOD_BARRAGE_COST
-					qdel(src)
-					if(user.put_in_hands(rite))
-						to_chat(user, span_cult("<b>Your hands glow with power!</b>"))
-					else
-						to_chat(user, span_cultitalic("You need a free hand for this rite!"))
-						qdel(rite)
-			if("Blood Beam (500)")
-				if(uses < BLOOD_BEAM_COST)
-					to_chat(user, span_cultitalic("You need [BLOOD_BEAM_COST] charges to perform this rite."))
+					to_chat(user, span_cultitalic("You need a free hand for this rite!"))
+					qdel(rite)
+		if(choice == "Bloody Beam (" + BLOOD_BEAM_COST + ")")
+			if(uses < BLOOD_BEAM_COST)
+				to_chat(user, span_cultitalic("You need [BLOOD_BEAM_COST] charges to perform this rite."))
+			else
+				var/obj/rite = new /obj/item/blood_beam()
+				uses -= BLOOD_BEAM_COST
+				qdel(src)
+				if(user.put_in_hands(rite))
+					to_chat(user, span_cultlarge("<b>Your hands glow with POWER OVERWHELMING!!!</b>"))
 				else
-					var/obj/rite = new /obj/item/blood_beam()
-					uses -= BLOOD_BEAM_COST
-					qdel(src)
-					if(user.put_in_hands(rite))
-						to_chat(user, span_cultlarge("<b>Your hands glow with POWER OVERWHELMING!!!</b>"))
-					else
-						to_chat(user, span_cultitalic("You need a free hand for this rite!"))
-						qdel(rite)
+					to_chat(user, span_cultitalic("You need a free hand for this rite!"))
+					qdel(rite)
 
 /obj/item/melee/blood_magic/manipulator/proc/check_menu(mob/living/user)
 	if(!istype(user))

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -477,15 +477,15 @@ structure_check() searches for nearby cultist structures required for the invoca
 //Ritual of Dimensional Rending: Calls forth the avatar of Nar'Sie upon the station.
 /obj/effect/rune/narsie
 	cultist_name = "Nar'Sie"
-	cultist_desc = "tears apart dimensional barriers, calling forth the Geometer. Requires 9 invokers."
+	cultist_desc = "tears apart dimensional barriers, calling forth the Geometer. Requires 4 invokers."
 	invocation = "TOK-LYR RQA-NAP G'OLT-ULOFT!!"
-	req_cultists = 9
+	req_cultists = 4
 	icon = 'icons/effects/96x96.dmi'
 	color = RUNE_COLOR_DARKRED
 	icon_state = "rune_large"
 	pixel_x = -32 //So the big ol' 96x96 sprite shows up right
 	pixel_y = -32
-	scribe_delay = 500 //how long the rune takes to create
+	scribe_delay = 750 //how long the rune takes to create
 	scribe_damage = 40.1 //how much damage you take doing it
 	log_when_erased = TRUE
 	erase_time = 5 SECONDS
@@ -649,9 +649,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 //Rite of Joined Souls: Summons a single cultist.
 /obj/effect/rune/summon
 	cultist_name = "Summon Cultist"
-	cultist_desc = "summons a single cultist to the rune. Requires 2 invokers."
+	cultist_desc = "summons a single cultist to the rune."
 	invocation = "N'ath reth sh'yro eth d'rekkathnor!"
-	req_cultists = 2
+	req_cultists = 1
 	invoke_damage = 10
 	icon_state = "3"
 	color = RUNE_COLOR_SUMMON
@@ -700,12 +700,12 @@ structure_check() searches for nearby cultist structures required for the invoca
 //Rite of Boiling Blood: Deals extremely high amounts of damage to non-cultists nearby
 /obj/effect/rune/blood_boil
 	cultist_name = "Boil Blood"
-	cultist_desc = "boils the blood of non-believers who can see the rune, rapidly dealing extreme amounts of damage. Requires 3 invokers."
+	cultist_desc = "boils the blood of non-believers who can see the rune, rapidly dealing extreme amounts of damage. Requires 2 invokers."
 	invocation = "Dedo ol'btoh!"
 	icon_state = "4"
 	color = RUNE_COLOR_BURNTORANGE
 	light_color = LIGHT_COLOR_LAVA
-	req_cultists = 3
+	req_cultists = 2
 	invoke_damage = 10
 	construct_invoke = FALSE
 	var/tick_damage = 25
@@ -893,7 +893,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	pixel_x = -32
 	pixel_y = -32
 	color = RUNE_COLOR_DARKRED
-	req_cultists = 3
+	req_cultists = 2
 	scribe_delay = 100
 
 /obj/effect/rune/apocalypse/invoke(list/invokers)


### PR DESCRIPTION

## About The Pull Request

This PR is created to balance Cultists in Low-Pop format, this is the start to sorting out the bigger issues, but obviously testing will be needed before hitting the rest of the Cultist items, runes, and spells.
A Cultist can only have 3 spells on them with a spell rune, instead of 4.
First, the cultist rate needed to obtain the red halo goes from 40% to 30% so that security can quickly notice the problem, to 40%, cultists will clearly outnumber the unconverted crew!
Then, the Blood Rite spell was well modified, the blood collected on the ground and a living carbon were (approximately) multiplied by two, making it possible to use the spell without needing to slaughter many NPC carbons.
You also need 25 Iron instead of 50 to make construct shells.
The Stun and Shackles spells have been nerfed about side effects, the stun paralyzes for 6 seconds instead of 16 (!!), and silence is changed from 12 seconds to 6. Shackles forces silence on the victim for 4 seconds, at instead of 10.
Finally, every rune that needs 2 Cultists or more to be activated will require 1 less (except the convert rune), and the final rune to end the round only needs 4 Cultists (Maybe that's not enough, but my opinion is that if it takes 5 or more, the security / crew will have very little, see no chance to defeating the cultusts), needs more time to draw the rune and activate it.

## Why It's Good For The Game

In the current state of things, it's impossible to use Cultists in a Low Pop format.

## Changelog
:cl:
balance: Spells Stun and Shackle nerfed in paralysing and mute duration
balance: Blood Rites buffed
balance: Runes which need 2 or more Cultists, have been adjusted to need 1 fewer Cultist (except the conversion rune)
balance: Spells helf on self by rune lowered from 4 to 3
balance: Crafting a Construct Shell requires less iron
balance: Red Halo given faster
/:cl:

