### PR TITLE
fix mining IDs

### DIFF
--- a/code/game/objects/items/card_access_chips.dm
+++ b/code/game/objects/items/card_access_chips.dm
@@ -1,6 +1,6 @@
 /obj/item/card_access_chip
 	name = "\improper AA-chip"
-	desc = "Additional Access chip, used to add higher tier access to lower tier cards."
+	desc = "Additional Access chip, used to add access to ID cards."
 	icon = 'icons/obj/new_id.dmi'
 	icon_state = "aa-chip-temp-codersprite-help" // TODO: get proper sprite
 
@@ -27,3 +27,8 @@
 	. = ..()
 	assignment = _assignment
 	name = "[_assignment] AA-chip"
+
+/obj/item/card_access_chip/mining
+	name = "mining access chip"
+	rewritable = FALSE // In case someone decides to change the base.
+	access = list(ACCESS_MAILSORTING, ACCESS_MECH_MINING, ACCESS_MINERAL_STOREROOM, ACCESS_MINING, ACCESS_MINING_STATION)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -659,6 +659,8 @@
 
 /obj/item/card/id/mining
 	name = "mining ID"
+	access_tier = 2
+	card_access = /datum/card_access/job/shaft_miner/spare
 
 /obj/item/card/id/highlander
 	name = "highlander ID"

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -270,7 +270,7 @@
 	new /obj/item/clothing/suit/hooded/explorer(src)
 	new /obj/item/encryptionkey/headset_mining(src)
 	new /obj/item/clothing/mask/gas/explorer(src)
-	new /obj/item/card/id/mining(src)
+	new /obj/item/card_access_chip/mining(src)
 	new /obj/item/gun/energy/kinetic_accelerator(src)
 	new /obj/item/kitchen/knife/combat/survival(src)
 	new /obj/item/flashlight/seclite(src)


### PR DESCRIPTION
mining IDs now have the correct assignment, also conscription kit has an AA-chip for mining access instead of an ID.