### PR TITLE
fix emitter icon_state not updating correctly when out of power.

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -158,7 +158,7 @@
 	if(!active || !powernet)
 		icon_state = base_icon_state
 		return ..()
-	icon_state = avail(active_power_usage) ? icon_state_on : icon_state_underpowered
+	icon_state = surplus() < active_power_usage ? icon_state_on : icon_state_underpowered
 	return ..()
 
 /obj/machinery/power/emitter/interact(mob/user)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -158,7 +158,7 @@
 	if(!active || !powernet)
 		icon_state = base_icon_state
 		return ..()
-	icon_state = surplus() < active_power_usage ? icon_state_on : icon_state_underpowered
+	icon_state = surplus() >= active_power_usage ? icon_state_on : icon_state_underpowered
 	return ..()
 
 /obj/machinery/power/emitter/interact(mob/user)


### PR DESCRIPTION
the check in proc/update_icon_state didn't match the check in proc/process
closes #71 