### PR TITLE
Fixes mapped smart pipes connecting incorrectly

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -90,9 +90,39 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 	icon = 'icons/obj/atmospherics/pipes/simple.dmi'
 	icon_state = "pipe11-3"
 
+/obj/machinery/atmospherics/pipe/smart/simple/LateInitialize()
+	. = ..()
+	if(initialize_directions == 0 || initialize_directions == ALL_CARDINALS)
+		// this shit is jank anyways so have a janky fix
+		var/w = 0
+		var/e = 0
+		var/n = 0
+		var/s = 0
+		if(dir & WEST)
+			w = 1
+		if(dir & EAST)
+			e = 1
+		if(dir & NORTH)
+			n = 1
+		if(dir & SOUTH)
+			s = 1
+		if((w || e) && (n || s))
+			initialize_directions = dir
+		else if(w || e)
+			initialize_directions = EAST | WEST
+		else initialize_directions = NORTH | SOUTH
+		update_pipe_icon()
+
 /obj/machinery/atmospherics/pipe/smart/manifold
 	icon = 'icons/obj/atmospherics/pipes/manifold.dmi'
 	icon_state = "manifold-3"
+
+/obj/machinery/atmospherics/pipe/smart/manifold/LateInitialize()
+	. = ..()
+	if(initialize_directions == 0 || initialize_directions == ALL_CARDINALS)
+		// this shit is jank anyways so have a janky fix
+		initialize_directions = ALL_CARDINALS ^ dir
+		update_pipe_icon()
 
 /obj/machinery/atmospherics/pipe/smart/manifold4w
 	icon = 'icons/obj/atmospherics/pipes/manifold.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
(Partially?) Fixes #84 because I don't need to do a complicated revert when I can make them work just fine.
If you still have issues then consider you might have an unironic skill issue.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to properly map smart pipes next to each other so they don't connect when you don't want them to is a pretty useful thing to have. Somebody who shall not be named who implemented them did not do his due diligence in making sure the mapping helpers worked correctly, and an unnamed maintainer merged it. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed tg's mess with smart pipes. Shame on you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
