### PR TITLE
Buffs space loot, gives whiteship it's own GPS.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/DJstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation.dmm
@@ -80,8 +80,8 @@
 /area/ruin/space/djstation)
 "as" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/suit/space/syndicate/orange,
+/obj/item/clothing/head/helmet/space/syndicate/orange,
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plating,
 /area/ruin/space/djstation)

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -1069,7 +1069,7 @@
 	},
 /area/ruin/space/derelict/singularity_engine)
 "eY" = (
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/syndicate/black/engie,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "eZ" = (
@@ -1136,7 +1136,7 @@
 	},
 /area/ruin/space/derelict/singularity_engine)
 "fk" = (
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/syndicate/black/engie,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "fl" = (
@@ -3317,7 +3317,7 @@
 /area/ruin/space/derelict/se_solar)
 "ob" = (
 /obj/machinery/light/small/directional/east,
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/syndicate/black/red,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/se_solar)
 "oc" = (
@@ -3346,7 +3346,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/se_solar)
 "oh" = (
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/syndicate/black/red,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/se_solar)
 "oi" = (
@@ -3482,7 +3482,7 @@
 	},
 /area/template_noop)
 "CZ" = (
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/syndicate/black/green,
 /turf/open/floor/iron/airless{
 	icon_state = "damaged2"
 	},
@@ -3646,7 +3646,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/bridge/ai_upload)
 "Ob" = (
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/syndicate/black/green,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/bridge/ai_upload)
 "Oj" = (

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -186,9 +186,8 @@
 /area/ruin/space/has_grav/abandonedzoo)
 "aT" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/space/eva,
 /obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/suit/space/hardsuit/medical,
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aV" = (

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -653,9 +653,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/derelictoutpost)
 "bY" = (
-/obj/item/gps{
-	gpstag = Distress Signal
-	},
+/obj/item/gps/spaceruin,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "ca" = (

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -653,7 +653,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/derelictoutpost)
 "bY" = (
-/obj/item/gps/spaceruin,
+/obj/item/gps{
+	gpstag = Distress Signal
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "ca" = (
@@ -1221,6 +1223,7 @@
 "dE" = (
 /obj/structure/alien/weeds/creature,
 /obj/structure/alien/weeds/creature,
+/obj/item/ammo_box/magazine/m45,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/derelictoutpost)
 "dF" = (

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -911,7 +911,9 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/secure/weapon,
-/obj/item/gun/energy/disabler,
+/obj/item/ammo_box/magazine/m9mm_aps/hp,
+/obj/item/ammo_box/magazine/m9mm_aps/hp,
+/obj/item/gun/ballistic/automatic/pistol/aps,
 /turf/open/floor/iron/dark/airless,
 /area/shuttle/caravan/freighter2)
 "iX" = (
@@ -919,6 +921,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/storage/box/slugs,
+/obj/item/gun/ballistic/shotgun/sc_pump,
 /turf/open/floor/iron/dark/airless,
 /area/shuttle/caravan/freighter2)
 "iY" = (

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1662,7 +1662,7 @@
 /area/awaymission/bmpship/aft)
 "gE" = (
 /obj/effect/decal/remains/human,
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/syndicate/green/dark,
 /obj/effect/gibspawner/generic,
 /turf/open/floor/plating/asteroid/airless,
 /area/awaymission/bmpship)
@@ -1721,7 +1721,7 @@
 /turf/open/floor/iron,
 /area/awaymission/bmpship/aft)
 "gQ" = (
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/syndicate/green/dark,
 /turf/open/floor/plating/asteroid/airless,
 /area/awaymission/bmpship)
 "gR" = (

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -177,6 +177,8 @@
 /obj/item/storage/box/mousetraps,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/storage/box/zipties,
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/ammo_box/magazine/m9mm,
 /obj/item/switchblade,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
@@ -1660,7 +1662,20 @@
 "ex" = (
 /obj/structure/table,
 /obj/structure/reagent_dispensers/peppertank/directional/east,
-/obj/effect/spawner/lootdrop/space/fancytool,
+/obj/item/gun/ballistic/automatic/wt550{
+	pixel_y = 3
+	},
+/obj/item/gun/ballistic/automatic/wt550{
+	pixel_y = -5
+	},
+/obj/item/ammo_box/magazine/wt550m9{
+	pixel_x = 4;
+	pixel_y = 12
+	},
+/obj/item/ammo_box/magazine/wt550m9{
+	pixel_x = 4;
+	pixel_y = 10
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "ey" = (
@@ -1821,6 +1836,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
+/obj/effect/spawner/lootdrop/space/fancytool,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "eP" = (

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -322,7 +322,7 @@
 /turf/open/floor/iron/dark/airless,
 /area/ruin/space/has_grav/gasthelizard)
 "S" = (
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/gasthelizard)
 "T" = (

--- a/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
@@ -332,9 +332,7 @@
 "bb" = (
 /obj/machinery/light/directional/east,
 /obj/structure/closet/cabinet,
-/obj/item/gps{
-	gpstag = Kitty
-	},
+/obj/item/gps/spaceruin,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/cat_man)
 "bc" = (

--- a/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
@@ -332,7 +332,9 @@
 "bb" = (
 /obj/machinery/light/directional/east,
 /obj/structure/closet/cabinet,
-/obj/item/gps/spaceruin,
+/obj/item/gps{
+	gpstag = Kitty
+	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/cat_man)
 "bc" = (

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -847,8 +847,8 @@
 "cI" = (
 /obj/structure/safe/floor,
 /obj/item/tank/internals/oxygen/red,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/suit/space/hardsuit/syndi,
 /obj/item/reagent_containers/food/drinks/bottle/rum,
 /obj/item/reagent_containers/food/drinks/bottle/rum,
 /obj/item/folder/syndicate/mining,

--- a/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
+++ b/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
@@ -595,7 +595,9 @@
 /obj/item/paper/crumpled/ruins/originalcontent,
 /obj/item/paper/crumpled/ruins/originalcontent,
 /obj/item/paper/crumpled/ruins/originalcontent,
-/obj/item/gps/spaceruin,
+/obj/item/gps{
+	gpstag = Pulpy Signal
+	},
 /turf/open/indestructible/paper,
 /area/ruin/powered)
 "bJ" = (

--- a/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
+++ b/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
@@ -595,9 +595,7 @@
 /obj/item/paper/crumpled/ruins/originalcontent,
 /obj/item/paper/crumpled/ruins/originalcontent,
 /obj/item/paper/crumpled/ruins/originalcontent,
-/obj/item/gps{
-	gpstag = Pulpy Signal
-	},
+/obj/item/gps/spaceruin,
 /turf/open/indestructible/paper,
 /area/ruin/powered)
 "bJ" = (

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -1827,9 +1827,7 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/item/gps{
-	gpstag = Twin-Nexus Hotel Retreat
-	},
+/obj/item/gps/spaceruin,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hotel/dock)
 "gw" = (

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -1827,8 +1827,8 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/item/gps/spaceruin{
-	name = "hotel gps"
+/obj/item/gps{
+	gpstag = Twin-Nexus Hotel Retreat
 	},
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hotel/dock)

--- a/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -186,6 +186,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/clothing/head/helmet/swat{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_y = -5
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/turretedoutpost)
 "aH" = (
@@ -356,6 +363,21 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/turretedoutpost)
+"CY" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/storage/belt/military,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/turretedoutpost)
 "Nu" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -495,7 +517,7 @@ ad
 at
 az
 aG
-aG
+CY
 az
 aX
 ad

--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -29,7 +29,9 @@
 /area/ruin/space/has_grav/whiteship/box)
 "gK" = (
 /obj/structure/table,
-/obj/item/gps/spaceruin,
+/obj/item/gps{
+	gpstag = Medical Transport
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
 "gO" = (
@@ -141,8 +143,7 @@
 /area/ruin/space/has_grav/whiteship/box)
 "sX" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/suit/space/hardsuit/medical,
 /obj/item/clothing/mask/breath,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)

--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -29,9 +29,7 @@
 /area/ruin/space/has_grav/whiteship/box)
 "gK" = (
 /obj/structure/table,
-/obj/item/gps{
-	gpstag = Medical Transport
-	},
+/obj/item/gps/spaceruin,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
 "gO" = (

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -1259,7 +1259,7 @@
 	pixel_x = 6
 	},
 /obj/item/gps{
-	gpstag = NTREC1
+	gpstag = "Medical Excursion Ship"
 	},
 /turf/open/floor/iron,
 /area/shuttle/abandoned/bridge)

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -135,7 +135,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/suit_storage_unit/cmo,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/crew)
 "ar" = (
@@ -1134,7 +1134,7 @@
 /area/shuttle/abandoned/bridge)
 "cb" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/computer/shuttle/white_ship/bridge{
+/obj/machinery/computer/shuttle/white_ship{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -1257,6 +1257,9 @@
 	id = "whiteship_bridge";
 	name = "Bridge Blast Door Control";
 	pixel_x = 6
+	},
+/obj/item/gps{
+	gpstag = NTREC1
 	},
 /turf/open/floor/iron,
 /area/shuttle/abandoned/bridge)
@@ -1852,7 +1855,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/suit_storage_unit/cmo,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/medbay)
 "dq" = (

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -322,7 +322,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/directional/north,
 /obj/item/gps{
-	gpstag = NTCONST1;
+	gpstag = "Civillian Mining Ship";
 	pixel_x = -1;
 	pixel_y = 2
 	},

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -321,6 +321,11 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/directional/north,
+/obj/item/gps{
+	gpstag = NTCONST1;
+	pixel_x = -1;
+	pixel_y = 2
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
 "aQ" = (
@@ -370,7 +375,7 @@
 /area/shuttle/abandoned)
 "aZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/computer/shuttle/white_ship/bridge{
+/obj/machinery/computer/shuttle/white_ship{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -998,12 +998,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/firealarm/directional/west,
+/obj/item/pen{
+	pixel_x = -4
+	},
+/obj/item/gps{
+	gpstag = NTREC1
+	},
 /obj/item/stack/spacecash/c200{
 	pixel_x = 7;
 	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = -4
 	},
 /obj/structure/spider/stickyweb,
 /obj/effect/turf_decal/tile/blue{
@@ -1119,14 +1122,14 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/bridge)
 "ch" = (
-/obj/machinery/computer/shuttle/white_ship/bridge{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/computer/shuttle/white_ship{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -1002,7 +1002,7 @@
 	pixel_x = -4
 	},
 /obj/item/gps{
-	gpstag = NTREC1
+	gpstag = "NT Exploration Ship"
 	},
 /obj/item/stack/spacecash/c200{
 	pixel_x = 7;

--- a/_maps/shuttles/whiteship_donut.dmm
+++ b/_maps/shuttles/whiteship_donut.dmm
@@ -468,7 +468,7 @@
 /turf/open/floor/iron/airless,
 /area/shuttle/abandoned)
 "bs" = (
-/obj/machinery/computer/shuttle/white_ship/bridge{
+/obj/machinery/computer/shuttle/white_ship{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -525,6 +525,21 @@
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"Kq" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/gps{
+	gpstag = White Ship
+	},
+/turf/open/floor/iron/airless,
 /area/shuttle/abandoned)
 
 (1,1,1) = {"
@@ -744,7 +759,7 @@ ag
 ab
 bc
 bn
-bo
+Kq
 bq
 "}
 (12,1,1) = {"

--- a/_maps/shuttles/whiteship_donut.dmm
+++ b/_maps/shuttles/whiteship_donut.dmm
@@ -537,7 +537,7 @@
 	dir = 4
 	},
 /obj/item/gps{
-	gpstag = White Ship
+	gpstag = "DISTRESS: WH173-5H1P"
 	},
 /turf/open/floor/iron/airless,
 /area/shuttle/abandoned)

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -1015,7 +1015,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/machinery/recharger,
 /obj/item/gps{
-	gpstag = BSE Singularity;
+	gpstag = "BSE Singularity";
 	pixel_x = -12;
 	pixel_y = 4
 	},

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -1015,7 +1015,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/machinery/recharger,
 /obj/item/gps{
-	gpstag = Salvage Ship;
+	gpstag = BSE Singularity;
 	pixel_x = -12;
 	pixel_y = 4
 	},

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -1014,6 +1014,11 @@
 /obj/structure/table,
 /obj/machinery/light/small/directional/east,
 /obj/machinery/recharger,
+/obj/item/gps{
+	gpstag = Salvage Ship;
+	pixel_x = -12;
+	pixel_y = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned/bridge)
 "bU" = (
@@ -1109,7 +1114,7 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned/crew)
 "cf" = (
-/obj/machinery/computer/shuttle/white_ship/bridge{
+/obj/machinery/computer/shuttle/white_ship{
 	dir = 4
 	},
 /obj/machinery/light/directional/west,

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -1651,7 +1651,7 @@
 	pixel_x = -12
 	},
 /obj/item/gps{
-	gpstag = NTREC1;
+	gpstag = Cargo Ship #753-25b;
 	pixel_x = 6;
 	pixel_y = 10
 	},

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -1651,7 +1651,7 @@
 	pixel_x = -12
 	},
 /obj/item/gps{
-	gpstag = Cargo Ship #753-25b;
+	gpstag = "Cargo Ship #753-25b";
 	pixel_x = 6;
 	pixel_y = 10
 	},

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -1538,7 +1538,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/bridge)
 "cv" = (
-/obj/machinery/computer/shuttle/white_ship/bridge{
+/obj/machinery/computer/shuttle/white_ship{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1649,6 +1649,11 @@
 	},
 /obj/item/wrench{
 	pixel_x = -12
+	},
+/obj/item/gps{
+	gpstag = NTREC1;
+	pixel_x = 6;
+	pixel_y = 10
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/bridge)

--- a/_maps/shuttles/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship_pubby.dmm
@@ -119,7 +119,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/table/glass,
 /obj/item/gps{
-	gpstag = Alien Signal;
+	gpstag = "Unidentified Spaceborne Signal";
 	pixel_x = -8;
 	pixel_y = 8
 	},

--- a/_maps/shuttles/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship_pubby.dmm
@@ -103,12 +103,11 @@
 /obj/structure/table/glass,
 /obj/item/tank/internals/oxygen,
 /obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/suit/space/hardsuit/engine/elite,
 /turf/open/floor/plating/abductor,
 /area/shuttle/abandoned)
 "q" = (
-/obj/machinery/computer/shuttle/white_ship/bridge{
+/obj/machinery/computer/shuttle/white_ship{
 	dir = 1
 	},
 /turf/open/floor/plating/abductor,
@@ -119,6 +118,11 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/table/glass,
+/obj/item/gps{
+	gpstag = Alien Signal;
+	pixel_x = -8;
+	pixel_y = 8
+	},
 /obj/item/clothing/shoes/magboots,
 /turf/open/floor/plating/abductor,
 /area/shuttle/abandoned)

--- a/_maps/shuttles/whiteship_tram.dmm
+++ b/_maps/shuttles/whiteship_tram.dmm
@@ -1093,6 +1093,10 @@
 "cU" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/gps{
+	gpstag = Freight Ship;
+	pixel_y = 2
+	},
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/abandoned/bridge)
 "cV" = (
@@ -1326,10 +1330,10 @@
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/abandoned/bridge)
 "dv" = (
-/obj/machinery/computer/shuttle/white_ship/bridge{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/shuttle/white_ship{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/abandoned/bridge)
 "dw" = (

--- a/_maps/shuttles/whiteship_tram.dmm
+++ b/_maps/shuttles/whiteship_tram.dmm
@@ -1094,7 +1094,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gps{
-	gpstag = "Cargo Freighter #194-62d;
+	gpstag = "Cargo Freighter #194-62d";
 	pixel_y = 2
 	},
 /turf/open/floor/mineral/titanium/tiled/blue,

--- a/_maps/shuttles/whiteship_tram.dmm
+++ b/_maps/shuttles/whiteship_tram.dmm
@@ -1094,7 +1094,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gps{
-	gpstag = Freight Ship;
+	gpstag = "Cargo Freighter #194-62d;
 	pixel_y = 2
 	},
 /turf/open/floor/mineral/titanium/tiled/blue,

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -299,11 +299,6 @@
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/shuttle/white_ship
 
-/obj/item/circuitboard/computer/white_ship/bridge
-	name = "White Ship Bridge (Computer Board)"
-	greyscale_colors = CIRCUIT_COLOR_GENERIC
-	build_path = /obj/machinery/computer/shuttle/white_ship/bridge
-
 /obj/item/circuitboard/computer/white_ship/pod
 	name = "Salvage Pod (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle/white_ship/pod

--- a/code/modules/shuttle/white_ship.dm
+++ b/code/modules/shuttle/white_ship.dm
@@ -5,16 +5,6 @@
 	shuttleId = "whiteship"
 	possible_destinations = "whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;whiteship_custom"
 
-/// Console used on the whiteship bridge. Comes with GPS pre-baked.
-/obj/machinery/computer/shuttle/white_ship/bridge
-	name = "White Ship Bridge Console"
-	desc = "Used to control the White Ship from the bridge. Emits a faint GPS signal."
-	circuit = /obj/item/circuitboard/computer/white_ship/bridge
-
-/obj/machinery/computer/shuttle/white_ship/bridge/Initialize(mapload, obj/item/circuitboard/C)
-	. = ..()
-	AddComponent(/datum/component/gps, SPACE_SIGNAL_GPSTAG)
-
 /obj/machinery/computer/shuttle/white_ship/pod
 	name = "Salvage Pod Console"
 	desc = "Used to control the Salvage Pod."


### PR DESCRIPTION
The Whiteships now have their own GPS signals.
Good space loot has been re-added.
This isn't the final change, but it's a good start to adjusting things for our codebase.

In the final PR, i'll most likely make all signals (except the whiteships) have a spaceruin signal, while in turn making sure every ruin will be worth visiting to some degree.