### PR TITLE
Fixes Laser arm cybernetics containing wrong protocols, and bundles it together with a syndicate cyberlink

### DIFF
--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -56,3 +56,12 @@
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis(src)
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis/l(src)
 	new /obj/item/autosurgeon/organ/cyberlink_syndicate(src)
+
+/obj/item/storage/briefcase/syndie_laser
+	desc = "Fully metallic briefcase. Has syndicate insignia engraved on the side."
+
+/obj/item/storage/briefcase/syndie_mantis/PopulateContents()
+	..()
+	new /obj/item/autosurgeon/organ/syndicate/laser_arm(src)
+	new /obj/item/autosurgeon/organ/cyberlink_syndicate(src)
+

--- a/code/modules/surgery/organs/cybernetics/augments_arms.dm
+++ b/code/modules/surgery/organs/cybernetics/augments_arms.dm
@@ -197,7 +197,7 @@
 	name = "arm-mounted laser implant"
 	desc = "A variant of the arm cannon implant that fires lethal laser beams. The cannon emerges from the subject's arm and remains inside when not in use."
 	icon_state = "arm_laser"
-	encode_info = AUGMENT_TG_LEVEL
+	encode_info = AUGMENT_SYNDICATE_LEVEL
 	contents = newlist(/obj/item/gun/energy/laser/mounted)
 
 /obj/item/organ/cyberimp/arm/item_set/gun/laser/l

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1997,7 +1997,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Laser Arm Implant"
 	desc = "An implant that grants you a recharging laser gun inside your arm. Weak to EMPs. Comes with a syndicate autosurgeon for immediate self-application."
 	cost = 10
-	item = /obj/item/autosurgeon/organ/syndicate/laser_arm
+	item = /obj/item/storage/briefcase/syndie_laser
 	restricted_roles = list("Roboticist", "Research Director")
 
 /datum/uplink_item/role_restricted/ocd_device


### PR DESCRIPTION

## About The Pull Request

Fixes laser arm having wrong hacking protocols and bundles it with a syndicate cyberlink


## Changelog
:cl:
add: Laser arm  now comes bundled with  syndicate cyberlink
fix: Laser arm now has syndicate hacking protocols instead of Terragov ones
/:cl:
