### PR TITLE
Makes mechs move diagonally again.

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -67,8 +67,6 @@
 	var/lights_power = 6
 	///Just stop the mech from doing anything
 	var/completely_disabled = FALSE
-	///Whether this mech is allowed to move diagonally
-	var/allow_diagonal_movement = FALSE
 	///Whether or not the mech destroys walls by running into it.
 	var/bumpsmash = FALSE
 
@@ -682,10 +680,6 @@
 
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		direction = pick(GLOB.alldirs)
-
-	//only mechs with diagonal movement may move diagonally
-	if(!allow_diagonal_movement && ISDIAGONALDIR(direction))
-		return TRUE
 
 	var/keyheld = FALSE
 	if(strafe)

--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -3,7 +3,6 @@
 	name = "\improper Gygax"
 	icon_state = "gygax"
 	base_icon_state = "gygax"
-	allow_diagonal_movement = TRUE
 	movedelay = 3
 	dir_in = 1 //Facing North.
 	max_integrity = 250

--- a/code/modules/vehicles/mecha/medical/odysseus.dm
+++ b/code/modules/vehicles/mecha/medical/odysseus.dm
@@ -3,7 +3,6 @@
 	name = "\improper Odysseus"
 	icon_state = "odysseus"
 	base_icon_state = "odysseus"
-	allow_diagonal_movement = TRUE
 	movedelay = 2
 	max_temperature = 15000
 	max_integrity = 120

--- a/code/modules/vehicles/mecha/working/working.dm
+++ b/code/modules/vehicles/mecha/working/working.dm
@@ -1,6 +1,5 @@
 /obj/vehicle/sealed/mecha/working
 	internal_damage_threshold = 60
-	allow_diagonal_movement = TRUE
 	/// Handles an internal ore box for working mechs
 	var/obj/structure/ore_box/box
 


### PR DESCRIPTION
DO NOT MERGE UNTIL #103 IS FIXED, THIS WILL CAUSE VISUAL AND BALANCE ISSUES!

This feature used to exist before the mech refactor, but got taken out for unknown reasons.
This PR makes any mech able to move diagonally.
With the linked bug fixed, diagonal movement speed will have the same slowdown as humans have, keeping it as a balanced QoL feature.