### PR TITLE
Adds Standard Lab Coats to Sci Vendors

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -162,6 +162,7 @@
 	products = list(/obj/item/clothing/glasses/hud/diagnostic = 2,
 					/obj/item/clothing/under/rank/rnd/roboticist = 2,
 					/obj/item/clothing/under/rank/rnd/roboticist/skirt = 2,
+					/obj/item/clothing/suit/toggle/labcoat = 2,
 					/obj/item/clothing/suit/toggle/labcoat/roboticist = 2,
 					/obj/item/clothing/suit/hooded/wintercoat/science/robotics = 3,
 					/obj/item/clothing/shoes/sneakers/black = 2,
@@ -192,6 +193,7 @@
 					/obj/item/clothing/under/rank/rnd/scientist = 3,
 					/obj/item/clothing/under/rank/rnd/scientist/skirt = 3,
 					/obj/item/clothing/suit/toggle/labcoat/science = 3,
+					/obj/item/clothing/suit/toggle/labcoat = 5,
 					/obj/item/clothing/shoes/sneakers/white = 3,
 					/obj/item/radio/headset/headset_sci = 3,
 					/obj/item/clothing/mask/gas = 3)


### PR DESCRIPTION
## About The Pull Request

What the title says

## Why It's Good For The Game

Let's science have access to plain white lab coats again in case people didn't care for the new trimmed coats.

## Changelog
:cl:
Adds 2 plain coats to the Robo vendor and 5 to the standard Sci vendor
/:cl:
