### PR TITLE
Adds simpson skintone

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -151,7 +151,8 @@ GLOBAL_LIST_INIT(skin_tones, sortList(list(
 	"arab",
 	"indian",
 	"african1",
-	"african2"
+	"african2",
+	"simpson"
 	)))
 
 GLOBAL_LIST_EMPTY(species_list)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -429,8 +429,10 @@
 						exposed_human.skin_tone = "african1"
 					if("arab")
 						exposed_human.skin_tone = "indian"
+					if("simpson")
+						exposed_human.skin_tone = "indian"
 					if("asian2")
-						exposed_human.skin_tone = "arab"
+						exposed_human.skin_tone = pick("arab", "simpson")
 					if("asian1")
 						exposed_human.skin_tone = "asian2"
 					if("mediterranean")

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -215,6 +215,8 @@
 			. = "fff4e6"
 		if("orange")
 			. = "ffc905"
+		if("simpson")
+			. = "fed90f"
 
 /mob/living/carbon/proc/Digitigrade_Leg_Swap(swap_back)
 	var/body_plan_changed = FALSE


### PR DESCRIPTION
The sign is a subtle joke. The shop is called "Sneed's Feed & Seed", where feed and seed both end in the sound "-eed", thus rhyming with the name of the owner, Sneed. The sign says that the shop was "Formerly Chuck's", implying that the two words beginning with "F" and "S" would have ended with "-uck", rhyming with "Chuck". So, when Chuck owned the shop, it would have been called "Chuck's Fuck and Suck".
![image](https://user-images.githubusercontent.com/75280571/163695630-b4ad14a7-1037-4103-984c-d266796545af.png)

:cl:
add: Well well, Look at the city slicker pulling up in his fancy German car
/:cl: