### PR TITLE
Strip down the Primary Treatment Center on MetaStation and add more wards

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -47708,9 +47708,6 @@
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/end{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "nIe" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -17609,8 +17609,8 @@
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
 /obj/item/storage/backpack/duffelbag/med/surgery{
-	step_x = -5;
-	step_y = 11
+	pixel_x = -5;
+	pixel_y = 11
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -22294,8 +22294,7 @@
 	},
 /obj/structure/bed/pod{
 	name = "medical bed";
-	desc = "An old medical bed, just waiting for replacement with something up to date.";
-	step_y = 0
+	desc = "An old medical bed, just waiting for replacement with something up to date."
 	},
 /obj/item/bedsheet/medical,
 /turf/open/floor/iron/white,
@@ -24852,8 +24851,6 @@
 	pixel_y = 8
 	},
 /obj/item/reagent_containers/chem_pack{
-	step_x = -1;
-	step_y = -3;
 	pixel_x = 10;
 	pixel_y = 10
 	},
@@ -34508,17 +34505,15 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/north,
 /obj/item/clothing/gloves/color/latex/nitrile{
-	step_y = 6
+	pixel_y = 6
 	},
 /obj/item/clothing/gloves/color/latex/nitrile{
-	step_y = 4
+	pixel_y = 4
 	},
 /obj/item/clothing/gloves/color/latex/nitrile{
-	step_y = 2
+	pixel_y = 2
 	},
-/obj/item/clothing/gloves/color/latex/nitrile{
-	step_y = 0
-	},
+/obj/item/clothing/gloves/color/latex/nitrile,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "jtP" = (
@@ -37986,8 +37981,8 @@
 "kCu" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery{
-	step_x = -5;
-	step_y = 11
+	pixel_x = -5;
+	pixel_y = 11
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -40569,8 +40564,7 @@
 "ltb" = (
 /obj/structure/bed/pod{
 	name = "medical bed";
-	desc = "An old medical bed, just waiting for replacement with something up to date.";
-	step_y = 0
+	desc = "An old medical bed, just waiting for replacement with something up to date."
 	},
 /obj/item/bedsheet/medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -48582,7 +48576,6 @@
 "nUV" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Primary Treatment Centre";
-	step_y = 0;
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
@@ -50857,7 +50850,7 @@
 	},
 /obj/machinery/light_switch/directional/west,
 /obj/item/storage/belt/medical{
-	step_y = 4
+	pixel_y = 4
 	},
 /obj/item/clothing/glasses/hud/health,
 /obj/structure/window/reinforced,
@@ -60410,7 +60403,7 @@
 	dir = 1
 	},
 /obj/item/storage/belt/medical{
-	step_y = 4
+	pixel_y = 4
 	},
 /obj/item/clothing/glasses/hud/health,
 /obj/structure/window/reinforced,
@@ -64447,9 +64440,7 @@
 /area/science/mixing)
 "tgQ" = (
 /obj/structure/water_source/puddle,
-/obj/structure/flora/junglebush/large{
-	pixel_y = 0
-	},
+/obj/structure/flora/junglebush/large,
 /obj/structure/cable,
 /turf/open/floor/grass,
 /area/medical/virology)
@@ -65505,7 +65496,7 @@
 	dir = 1
 	},
 /obj/item/storage/belt/medical{
-	step_y = 4
+	pixel_y = 4
 	},
 /obj/item/clothing/glasses/hud/health,
 /obj/structure/window/reinforced{
@@ -67223,8 +67214,8 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /obj/item/storage/backpack/duffelbag/med/surgery{
-	step_x = -5;
-	step_y = 11
+	pixel_x = -5;
+	pixel_y = 11
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -72313,8 +72304,7 @@
 /obj/machinery/light/directional/south,
 /obj/structure/bed/pod{
 	name = "medical bed";
-	desc = "An old medical bed, just waiting for replacement with something up to date.";
-	step_y = 0
+	desc = "An old medical bed, just waiting for replacement with something up to date."
 	},
 /obj/item/bedsheet/medical,
 /turf/open/floor/iron/white,
@@ -72893,7 +72883,7 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /obj/item/storage/belt/medical{
-	step_y = 4
+	pixel_y = 4
 	},
 /obj/item/clothing/glasses/hud/health,
 /obj/structure/window/reinforced{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2504,27 +2504,6 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"arw" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Primary Treatment Centre";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "ary" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -2809,10 +2788,10 @@
 	},
 /area/maintenance/fore)
 "aud" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/treatment_center)
 "auo" = (
@@ -4287,13 +4266,8 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "aGx" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/end{
-	dir = 1
-	},
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "aGE" = (
@@ -4806,9 +4780,6 @@
 "aLr" = (
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -7195,13 +7166,11 @@
 /turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "biR" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "biX" = (
@@ -14751,11 +14720,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cSM" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/treatment_center)
 "cSW" = (
@@ -15339,6 +15308,9 @@
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4,
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cZj" = (
@@ -15354,27 +15326,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cZr" = (
-/obj/structure/table/glass,
-/obj/item/scalpel{
-	pixel_y = 12
-	},
-/obj/item/circular_saw,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/blood_filter,
 /obj/machinery/light/directional/north,
-/obj/item/bonesetter,
 /obj/machinery/button/door/directional/north{
 	id = "main_surgery";
 	name = "privacy shutters control"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -15743,6 +15701,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"dfI" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "dfV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -16361,16 +16326,6 @@
 	},
 /area/maintenance/port/fore)
 "dob" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/disposal/bin{
 	desc = "A pneumatic waste disposal unit. This one leads to the morgue.";
 	name = "corpse disposal"
@@ -16379,6 +16334,9 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dod" = (
@@ -16804,14 +16762,6 @@
 "dux" = (
 /turf/closed/wall,
 /area/maintenance/port/aft)
-"duA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "duH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17646,7 +17596,6 @@
 "dGV" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
-/obj/item/surgical_drapes,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -17659,6 +17608,10 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	step_x = -5;
+	step_y = 11
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dHf" = (
@@ -18216,12 +18169,12 @@
 /turf/open/floor/iron/dark,
 /area/medical/break_room)
 "dPN" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -18430,6 +18383,12 @@
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/iron,
 /area/commons/locker)
+"dUT" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "dVf" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#0000FF";
@@ -19387,7 +19346,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "ekJ" = (
@@ -19853,9 +19813,6 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "etb" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -19863,6 +19820,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/treatment_center)
 "etd" = (
@@ -21498,6 +21456,10 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "Medbay Storage";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "eRd" = (
@@ -22322,6 +22284,22 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
+"fei" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/bed/pod{
+	name = "medical bed";
+	desc = "An old medical bed, just waiting for replacement with something up to date.";
+	step_y = 0
+	},
+/obj/item/bedsheet/medical,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "fen" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -22918,10 +22896,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "fpi" = (
-/obj/structure/table/glass,
-/obj/item/retractor,
-/obj/item/hemostat,
-/obj/item/cautery,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -22930,6 +22904,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/computer/operating{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -23032,6 +23009,9 @@
 /obj/machinery/iv_drip,
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "fqK" = (
@@ -23699,35 +23679,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"fAB" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 6
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 4
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/storage/belt/medical,
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/medical/treatment_center)
 "fBb" = (
 /obj/machinery/camera{
 	c_tag = "Dormitories - Aft";
@@ -23829,10 +23780,17 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "fBL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
 /obj/effect/landmark/start/medical_doctor,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "fBP" = (
@@ -24601,10 +24559,6 @@
 	dir = 4
 	},
 /area/service/chapel/main)
-"fPM" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/floor/grass,
-/area/medical/treatment_center)
 "fPR" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -24893,6 +24847,19 @@
 	dir = 4;
 	network = list("ss13","medbay")
 	},
+/obj/item/storage/box/rxglasses{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/chem_pack{
+	step_x = -1;
+	step_y = -3;
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/item/stack/medical/gauze{
+	pixel_x = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "fXC" = (
@@ -25102,7 +25069,7 @@
 /area/engineering/atmos)
 "gaN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -25148,7 +25115,18 @@
 	pixel_y = 3
 	},
 /obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -26494,13 +26472,10 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "gAD" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Storage";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "gAE" = (
@@ -26940,14 +26915,14 @@
 "gHm" = (
 /obj/machinery/light/directional/west,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4{
 	dir = 6
 	},
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -28209,12 +28184,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"hks" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "hkv" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -28967,10 +28936,10 @@
 	pixel_x = 14
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
 "hwZ" = (
@@ -31882,10 +31851,10 @@
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -32176,6 +32145,10 @@
 	},
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4,
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "iBF" = (
@@ -32246,32 +32219,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/medical/central)
-"iCJ" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/stack/medical/mesh,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side{
-	dir = 6
-	},
-/area/medical/treatment_center)
 "iCK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32593,10 +32540,10 @@
 /turf/open/floor/iron,
 /area/construction/storage_wing)
 "iIV" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/treatment_center)
 "iJf" = (
@@ -33478,6 +33425,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/item/stack/medical/mesh,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "iZa" = (
@@ -34485,11 +34433,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "jsx" = (
-/obj/structure/table/glass,
-/obj/item/scalpel{
-	pixel_y = 12
-	},
-/obj/item/circular_saw,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -34500,13 +34443,12 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/item/blood_filter,
 /obj/machinery/light/directional/south,
-/obj/item/bonesetter,
 /obj/machinery/button/door/directional/south{
 	id = "main_surgery";
 	name = "privacy shutters control"
 	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "jsA" = (
@@ -34565,11 +34507,18 @@
 "jtM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/north,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/wrench/medical,
+/obj/item/clothing/gloves/color/latex/nitrile{
+	step_y = 6
+	},
+/obj/item/clothing/gloves/color/latex/nitrile{
+	step_y = 4
+	},
+/obj/item/clothing/gloves/color/latex/nitrile{
+	step_y = 2
+	},
+/obj/item/clothing/gloves/color/latex/nitrile{
+	step_y = 0
+	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "jtP" = (
@@ -34802,6 +34751,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"jzd" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "jzk" = (
 /obj/structure/table/glass,
 /obj/structure/reagent_dispensers/virusfood/directional/west,
@@ -38030,7 +37985,10 @@
 /area/science/test_area)
 "kCu" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	step_x = -5;
+	step_y = 11
+	},
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
@@ -39170,23 +39128,9 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "kWy" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
-	},
-/obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/storage)
 "kWE" = (
 /obj/machinery/camera{
@@ -39662,9 +39606,6 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/satellite)
 "lec" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4{
 	dir = 4
 	},
@@ -39672,6 +39613,9 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "lee" = (
@@ -39870,6 +39814,23 @@
 	},
 /turf/open/floor/iron,
 /area/command/teleporter)
+"lhQ" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/iv_drip,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "lhR" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4,
@@ -40084,7 +40045,19 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "llx" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "llG" = (
@@ -40594,8 +40567,18 @@
 /turf/open/floor/circuit/green,
 /area/science/nanite)
 "ltb" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/structure/bed/pod{
+	name = "medical bed";
+	desc = "An old medical bed, just waiting for replacement with something up to date.";
+	step_y = 0
+	},
+/obj/item/bedsheet/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -41623,6 +41606,9 @@
 	pixel_x = -12;
 	pixel_y = -2
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "lNk" = (
@@ -41651,6 +41637,27 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"lND" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/storage/box/gloves{
+	pixel_y = 8
+	},
+/obj/item/storage/box/masks{
+	pixel_y = 4
+	},
+/obj/item/storage/box/bodybags,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "lNG" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4,
@@ -42189,11 +42196,11 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "lXD" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4,
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lXM" = (
@@ -43980,13 +43987,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"mAI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "mBw" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
@@ -45182,22 +45182,14 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "mVP" = (
-/obj/machinery/computer/operating,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Medbay Primary Surgery";
 	dir = 4;
 	name = "medical camera";
 	network = list("ss13","medical")
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -45494,6 +45486,11 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
+"naH" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "naM" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/secure{
@@ -45534,8 +45531,18 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/item/radio/intercom/directional/south,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Surgical Supplies";
+	req_access_txt = "45"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/stack/sticky_tape/surgical,
+/obj/item/stack/medical/bone_gel,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "nbk" = (
@@ -46140,10 +46147,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "njh" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "njk" = (
@@ -46389,10 +46396,6 @@
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "noi" = (
-/obj/structure/table/glass,
-/obj/item/retractor,
-/obj/item/hemostat,
-/obj/item/cautery,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -46403,6 +46406,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/computer/operating{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "nok" = (
@@ -47400,11 +47406,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "nCO" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/duct,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "nCP" = (
@@ -47432,6 +47445,12 @@
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"nDu" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "nDM" = (
 /obj/structure/fireaxecabinet/directional/south,
 /obj/item/paper_bin{
@@ -47685,11 +47704,13 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "nHX" = (
-/obj/machinery/duct,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/end{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "nIe" = (
@@ -48561,6 +48582,28 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
+"nUV" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Primary Treatment Centre";
+	step_y = 0;
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "nVm" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -48749,12 +48792,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
-"nYp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "nYI" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
@@ -49538,20 +49575,13 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "omP" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/shower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "omY" = (
@@ -49903,23 +49933,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"otE" = (
-/obj/machinery/medical_kiosk,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/medical/treatment_center)
 "otK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -50159,12 +50172,6 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/iron,
 /area/engineering/main)
-"oxQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "oyB" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice,
@@ -50568,24 +50575,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"oFa" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "oFf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -50870,6 +50859,11 @@
 	dir = 1
 	},
 /obj/machinery/light_switch/directional/west,
+/obj/item/storage/belt/medical{
+	step_y = 4
+	},
+/obj/item/clothing/glasses/hud/health,
+/obj/structure/window/reinforced,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "oKE" = (
@@ -52706,6 +52700,9 @@
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "ppi" = (
@@ -53576,10 +53573,8 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "pGd" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "pGf" = (
@@ -54018,9 +54013,6 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "pOk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -54311,6 +54303,25 @@
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"pSO" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/bottle/multiver{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/reagent_containers/syringe,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "pSX" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Escape Airlock"
@@ -54531,9 +54542,6 @@
 "pWK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/surgery)
@@ -55184,11 +55192,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/fore)
-"qik" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "qim" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -56209,18 +56212,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "qCw" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/shower{
-	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -56777,19 +56770,9 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "qLC" = (
-/obj/machinery/computer/operating{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "qLI" = (
@@ -57022,20 +57005,6 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
-"qPh" = (
-/obj/machinery/door/window/southright{
-	dir = 8;
-	name = "Surgical Supplies";
-	req_access_txt = "45"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/stack/sticky_tape/surgical,
-/obj/item/stack/medical/bone_gel,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "qPM" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -57826,6 +57795,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
+"rcU" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "rcX" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
@@ -57988,30 +57973,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"rfD" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/siding/white/corner,
-/obj/item/storage/box/gloves{
-	pixel_y = 8
-	},
-/obj/item/storage/box/masks{
-	pixel_y = 4
-	},
-/obj/item/storage/box/bodybags,
-/turf/open/floor/iron/white/side{
-	dir = 9
-	},
-/area/medical/treatment_center)
 "rfK" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/light/small/directional/north,
@@ -59961,7 +59922,9 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "rKP" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "rKT" = (
@@ -60437,6 +60400,25 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
+"rRg" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/storage/belt/medical{
+	step_y = 4
+	},
+/obj/item/clothing/glasses/hud/health,
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "rRC" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Crematorium";
@@ -60746,11 +60728,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "rWs" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4,
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rWw" = (
@@ -63946,10 +63928,13 @@
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -65510,6 +65495,28 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
+"twD" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/storage/belt/medical{
+	step_y = 4
+	},
+/obj/item/clothing/glasses/hud/health,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "twK" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/chapel{
@@ -65540,13 +65547,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "txn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/machinery/duct,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "txp" = (
@@ -65687,6 +65688,7 @@
 /obj/machinery/cell_charger,
 /obj/machinery/firealarm/directional/north,
 /obj/item/radio/intercom/directional/west,
+/obj/item/wrench/medical,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "tBm" = (
@@ -66943,15 +66945,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -67219,7 +67214,6 @@
 "uby" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
-/obj/item/surgical_drapes,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -67231,6 +67225,10 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	step_x = -5;
+	step_y = 11
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "ubD" = (
@@ -68234,27 +68232,17 @@
 /area/security/prison)
 "urw" = (
 /obj/machinery/duct,
-/obj/machinery/door/airlock/medical{
-	name = "Primary Surgical Theatre";
-	req_access_txt = "45"
-	},
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "main_surgery"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/treatment_center)
 "urH" = (
 /obj/machinery/turretid{
@@ -70381,6 +70369,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
+/obj/machinery/shower,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "vaD" = (
@@ -70542,9 +70531,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "vdD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4{
 	dir = 4
 	},
@@ -70552,6 +70538,9 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "vdF" = (
@@ -70786,6 +70775,25 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
+"vic" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "vio" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -70889,6 +70897,7 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/treatment_center)
 "vjl" = (
@@ -71495,7 +71504,6 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "vsu" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
@@ -71765,30 +71773,6 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/medical/medbay/central)
-"vwl" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/reagent_containers/glass/bottle/multiver{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/reagent_containers/syringe,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white/side{
-	dir = 5
-	},
-/area/medical/treatment_center)
 "vwp" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -72137,11 +72121,10 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "vCP" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "vCY" = (
@@ -72332,9 +72315,11 @@
 /obj/machinery/defibrillator_mount/directional/south,
 /obj/machinery/light/directional/south,
 /obj/structure/bed/pod{
+	name = "medical bed";
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
-	name = "medical bed"
+	step_y = 0
 	},
+/obj/item/bedsheet/medical,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "vFb" = (
@@ -72910,6 +72895,14 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/item/storage/belt/medical{
+	step_y = 4
+	},
+/obj/item/clothing/glasses/hud/health,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "vPe" = (
@@ -73063,24 +73056,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "vSs" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Primary Treatment Centre";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4{
 	dir = 4
 	},
@@ -73088,7 +73063,8 @@
 	dir = 8
 	},
 /obj/machinery/duct,
-/turf/open/floor/iron/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/treatment_center)
 "vSt" = (
 /obj/structure/cable,
@@ -73227,26 +73203,14 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "vUo" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4,
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side,
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "vUI" = (
 /obj/structure/table/glass,
@@ -74089,10 +74053,20 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "wjS" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/duct,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/duct,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "wkj" = (
@@ -74212,6 +74186,9 @@
 	dir = 1
 	},
 /obj/machinery/iv_drip,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "wlz" = (
@@ -74975,8 +74952,11 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "wAr" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -75291,13 +75271,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "wFT" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4,
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -75518,7 +75496,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "wKa" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -76010,7 +75988,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -76524,33 +76501,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "xcv" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = 6
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/hud/health,
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "xcA" = (
 /obj/structure/disposalpipe/segment{
@@ -76915,21 +76866,11 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "xhZ" = (
-/obj/machinery/door/airlock/medical{
-	name = "Primary Surgical Theatre";
-	req_access_txt = "45"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "main_surgery"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/treatment_center)
 "xih" = (
 /obj/effect/mapping_helpers/simple_pipes/orange/hidden{
@@ -77154,14 +77095,14 @@
 /turf/open/floor/carpet,
 /area/service/library)
 "xly" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -78856,11 +78797,21 @@
 /turf/open/floor/plating,
 /area/engineering/secondary_engine)
 "xMZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "main_surgery"
+/obj/machinery/door/airlock/medical{
+	name = "Primary Surgical Theatre";
+	req_access_txt = "45"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "xNc" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -78904,40 +78855,13 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "xNx" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/reagent_containers/chem_pack{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/obj/item/storage/box/rxglasses{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/stack/medical/gauze{
-	pixel_x = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white/side{
-	dir = 10
-	},
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "xNJ" = (
 /obj/effect/turf_decal/plaque{
@@ -79497,6 +79421,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xYO" = (
@@ -99065,7 +98992,7 @@ puR
 cia
 dGV
 clW
-wKa
+dUT
 pOk
 wKa
 qAL
@@ -99582,7 +99509,7 @@ aLr
 pWK
 trM
 wSW
-upD
+ccf
 nbi
 cia
 slf
@@ -99839,7 +99766,7 @@ qCw
 gaN
 tPt
 iug
-qPh
+upD
 gce
 cia
 bXE
@@ -100864,8 +100791,8 @@ mRw
 poU
 wjS
 rKP
-tiA
-tiA
+fei
+nDu
 xly
 biR
 llx
@@ -101119,9 +101046,9 @@ nNs
 ngr
 iRL
 sCr
-pGd
-llx
-rfD
+dfI
+jzd
+xcv
 xcv
 xNx
 dPN
@@ -101377,14 +101304,14 @@ vFz
 iUs
 ltE
 oTG
-llx
-otE
-fPM
+xcv
+fei
+nDu
 vUo
 txn
 vjg
 aGx
-nVZ
+vic
 gAD
 coA
 kwz
@@ -101631,17 +101558,17 @@ dfV
 jLY
 gOi
 sSK
-iRL
+mRw
 vay
+tiA
 yiv
-llx
-vwl
-fAB
-iCJ
-dPN
-qik
+xcv
+xcv
+xNx
+naH
+tiA
 ekI
-oFa
+kWy
 gZw
 rwO
 lXv
@@ -101890,14 +101817,14 @@ jUU
 tOu
 mRw
 fqA
-oxQ
-hks
-nYp
-nYp
+rcU
+rKP
+fei
+nDu
 vdD
 pGd
-llx
-wkY
+rcU
+lhQ
 nVZ
 ujM
 jex
@@ -102147,13 +102074,13 @@ kBd
 eTz
 mRw
 jqO
-duA
+nCO
 aud
 vzk
 vzk
 trS
 iIV
-mAI
+fBL
 vEY
 bXK
 wTy
@@ -102403,15 +102330,15 @@ dwf
 jtH
 nuj
 mRw
-iYO
-iYO
+lND
+rRg
 jmR
 ltb
 luE
 lec
 vsu
-iYO
-iYO
+twD
+pSO
 bXK
 ldH
 loL
@@ -102662,11 +102589,11 @@ lyX
 mRw
 mRw
 mRw
+nUV
 iRL
-arw
-iRL
+mRw
 vSs
-iRL
+nUV
 mRw
 mRw
 bXK


### PR DESCRIPTION
## About The Pull Request

The primary treatment center in the medbay has had all the junk in the middle stripped out, and in its place, 4 more wards for waiting patients have been added. Minor tweaks have also been made to the Primary Surgical Theatre and other neighboring rooms in order to make them function better alongside the revamped medbay.
![image](https://user-images.githubusercontent.com/34369281/163850568-d13936d5-14df-40df-b737-389864ef691b.png)


## Why It's Good For The Game

Medbay on highpop or just very active rounds can end up as a massive mess, with even four fully setup stasis beds/operating tables with operating computers often not being able to pick up the slack. These extra wards, while not pretty, are very functional, giving ample room to set up a full operating theatre for a patient to be worked on, with room to install the medical devices mentioned just before.

## Changelog
:cl:
add: Added MetaStation medbay wards
qol: Put the surgical tools in the primary surgical theatre into surgical duffel bags, moved tables around
del: Removed the medical kiosk and tables in the middle of the medbay
del: Got rid of that stupid fucking potted plant, fuck that thing, piece of shit
/:cl: