### PR TITLE
Hand Radio Update - Station-Bounced radio now functionally similar to a headset

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -6,6 +6,7 @@
 	worn_icon_state = null
 	custom_materials = list(/datum/material/iron=75)
 	canhear_range = 0 // can't hear headsets from very far away
+	subspace_switchable = FALSE
 
 	slot_flags = ITEM_SLOT_EARS
 	dog_fashion = null

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -1,19 +1,3 @@
-// Used for translating channels to tokens on examination
-GLOBAL_LIST_INIT(channel_tokens, list(
-	RADIO_CHANNEL_COMMON = RADIO_KEY_COMMON,
-	RADIO_CHANNEL_SCIENCE = RADIO_TOKEN_SCIENCE,
-	RADIO_CHANNEL_COMMAND = RADIO_TOKEN_COMMAND,
-	RADIO_CHANNEL_MEDICAL = RADIO_TOKEN_MEDICAL,
-	RADIO_CHANNEL_ENGINEERING = RADIO_TOKEN_ENGINEERING,
-	RADIO_CHANNEL_SECURITY = RADIO_TOKEN_SECURITY,
-	RADIO_CHANNEL_CENTCOM = RADIO_TOKEN_CENTCOM,
-	RADIO_CHANNEL_SYNDICATE = RADIO_TOKEN_SYNDICATE,
-	RADIO_CHANNEL_SUPPLY = RADIO_TOKEN_SUPPLY,
-	RADIO_CHANNEL_SERVICE = RADIO_TOKEN_SERVICE,
-	MODE_BINARY = MODE_TOKEN_BINARY,
-	RADIO_CHANNEL_AI_PRIVATE = RADIO_TOKEN_AI_PRIVATE
-))
-
 /obj/item/radio/headset
 	name = "radio headset"
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys."
@@ -21,45 +5,14 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	inhand_icon_state = "headset"
 	worn_icon_state = null
 	custom_materials = list(/datum/material/iron=75)
-	subspace_transmission = TRUE
 	canhear_range = 0 // can't hear headsets from very far away
 
 	slot_flags = ITEM_SLOT_EARS
-	var/obj/item/encryptionkey/keyslot2 = null
 	dog_fashion = null
 
 /obj/item/radio/headset/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins putting \the [src]'s antenna up [user.p_their()] nose! It looks like [user.p_theyre()] trying to give [user.p_them()]self cancer!"))
 	return TOXLOSS
-
-/obj/item/radio/headset/examine(mob/user)
-	. = ..()
-
-	if(item_flags & IN_INVENTORY && loc == user)
-		// construction of frequency description
-		var/list/avail_chans = list("Use [RADIO_KEY_COMMON] for the currently tuned frequency")
-		if(translate_binary)
-			avail_chans += "use [MODE_TOKEN_BINARY] for [MODE_BINARY]"
-		if(length(channels))
-			for(var/i in 1 to length(channels))
-				if(i == 1)
-					avail_chans += "use [MODE_TOKEN_DEPARTMENT] or [GLOB.channel_tokens[channels[i]]] for [lowertext(channels[i])]"
-				else
-					avail_chans += "use [GLOB.channel_tokens[channels[i]]] for [lowertext(channels[i])]"
-		. += span_notice("A small screen on the headset displays the following available frequencies:\n[english_list(avail_chans)].")
-
-		if(command)
-			. += span_info("Alt-click to toggle the high-volume mode.")
-	else
-		. += span_notice("A small screen on the headset flashes, it's too small to read without holding or wearing the headset.")
-
-/obj/item/radio/headset/Initialize()
-	. = ..()
-	recalculateChannels()
-
-/obj/item/radio/headset/Destroy()
-	QDEL_NULL(keyslot2)
-	return ..()
 
 /obj/item/radio/headset/talk_into(mob/living/M, message, channel, list/spans, datum/language/language, list/message_mods)
 	if (!listening)
@@ -284,66 +237,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/silicon/can_receive(freq, level)
 	return ..(freq, level, TRUE)
-
-/obj/item/radio/headset/attackby(obj/item/W, mob/user, params)
-	user.set_machine(src)
-
-	if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(keyslot || keyslot2)
-			for(var/ch_name in channels)
-				SSradio.remove_object(src, GLOB.radiochannels[ch_name])
-				secure_radio_connections[ch_name] = null
-
-			if(keyslot)
-				user.put_in_hands(keyslot)
-				keyslot = null
-			if(keyslot2)
-				user.put_in_hands(keyslot2)
-				keyslot2 = null
-
-			recalculateChannels()
-			to_chat(user, span_notice("You pop out the encryption keys in the headset."))
-
-		else
-			to_chat(user, span_warning("This headset doesn't have any unique encryption keys! How useless..."))
-
-	else if(istype(W, /obj/item/encryptionkey))
-		if(keyslot && keyslot2)
-			to_chat(user, span_warning("The headset can't hold another key!"))
-			return
-
-		if(!keyslot)
-			if(!user.transferItemToLoc(W, src))
-				return
-			keyslot = W
-
-		else
-			if(!user.transferItemToLoc(W, src))
-				return
-			keyslot2 = W
-
-
-		recalculateChannels()
-	else
-		return ..()
-
-
-/obj/item/radio/headset/recalculateChannels()
-	..()
-	if(keyslot2)
-		for(var/ch_name in keyslot2.channels)
-			if(!(ch_name in src.channels))
-				channels[ch_name] = keyslot2.channels[ch_name]
-
-		if(keyslot2.translate_binary)
-			translate_binary = TRUE
-		if(keyslot2.syndie)
-			syndie = TRUE
-		if (keyslot2.independent)
-			independent = TRUE
-
-	for(var/ch_name in channels)
-		secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])
 
 /obj/item/radio/headset/AltClick(mob/living/user)
 	if(!istype(user) || !Adjacent(user) || user.incapacitated())

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -1,16 +1,31 @@
 #define FREQ_LISTENING (1<<0)
 
+// Used for translating channels to tokens on examination
+GLOBAL_LIST_INIT(channel_tokens, list(
+	RADIO_CHANNEL_COMMON = RADIO_KEY_COMMON,
+	RADIO_CHANNEL_SCIENCE = RADIO_TOKEN_SCIENCE,
+	RADIO_CHANNEL_COMMAND = RADIO_TOKEN_COMMAND,
+	RADIO_CHANNEL_MEDICAL = RADIO_TOKEN_MEDICAL,
+	RADIO_CHANNEL_ENGINEERING = RADIO_TOKEN_ENGINEERING,
+	RADIO_CHANNEL_SECURITY = RADIO_TOKEN_SECURITY,
+	RADIO_CHANNEL_CENTCOM = RADIO_TOKEN_CENTCOM,
+	RADIO_CHANNEL_SYNDICATE = RADIO_TOKEN_SYNDICATE,
+	RADIO_CHANNEL_SUPPLY = RADIO_TOKEN_SUPPLY,
+	RADIO_CHANNEL_SERVICE = RADIO_TOKEN_SERVICE,
+	MODE_BINARY = MODE_TOKEN_BINARY,
+	RADIO_CHANNEL_AI_PRIVATE = RADIO_TOKEN_AI_PRIVATE
+))
+
 /obj/item/radio
 	icon = 'icons/obj/radio.dmi'
-	name = "station bounced radio"
+	name = "hand radio"
 	icon_state = "walkietalkie"
 	inhand_icon_state = "walkietalkie"
 	worn_icon_state = "radio"
-	desc = "A basic handheld radio that communicates with local telecommunication networks."
+	desc = "A basic handheld radio that communicates on the station's subspace network."
 	dog_fashion = /datum/dog_fashion/back
 
 	flags_1 = CONDUCT_1
-	slot_flags = ITEM_SLOT_BELT
 	throw_speed = 3
 	throw_range = 7
 	w_class = WEIGHT_CLASS_SMALL
@@ -27,7 +42,7 @@
 	var/prison_radio = FALSE  // If true, the transmit wire starts cut.
 	var/unscrewed = FALSE  // Whether wires are accessible. Toggleable by screwdrivering.
 	var/freerange = FALSE  // If true, the radio has access to the full spectrum.
-	var/subspace_transmission = FALSE  // If true, the radio transmits and receives on subspace exclusively.
+	var/subspace_transmission = TRUE  // If true, the radio transmits and receives on subspace exclusively.
 	var/subspace_switchable = FALSE  // If true, subspace_transmission can be toggled at will.
 	var/freqlock = FALSE  // Frequency lock to stop the user from untuning specialist radios.
 	var/use_command = FALSE  // If true, broadcasts will be large and BOLD.
@@ -38,6 +53,7 @@
 
 	// Encryption key handling
 	var/obj/item/encryptionkey/keyslot
+	var/obj/item/encryptionkey/keyslot2
 	var/translate_binary = FALSE  // If true, can hear the special binary channel.
 	var/independent = FALSE  // If true, can say/hear on the special CentCom channel.
 	var/syndie = FALSE  // If true, hears all well-known channels automatically, and can say/hear on the Syndicate channel.
@@ -68,6 +84,18 @@
 		if(keyslot.independent)
 			independent = TRUE
 
+	if(keyslot2)
+		for(var/ch_name in keyslot2.channels)
+			if(!(ch_name in src.channels))
+				channels[ch_name] = keyslot2.channels[ch_name]
+
+		if(keyslot2.translate_binary)
+			translate_binary = TRUE
+		if(keyslot2.syndie)
+			syndie = TRUE
+		if (keyslot2.independent)
+			independent = TRUE
+
 	for(var/ch_name in channels)
 		secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])
 
@@ -88,6 +116,8 @@
 	remove_radio_all(src) //Just to be sure
 	QDEL_NULL(wires)
 	QDEL_NULL(keyslot)
+	QDEL_NULL(keyslot2)
+
 	return ..()
 
 /obj/item/radio/Initialize()
@@ -103,6 +133,8 @@
 		secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])
 
 	become_hearing_sensitive(ROUNDSTART_TRAIT)
+
+	recalculateChannels()
 
 /obj/item/radio/ComponentInitialize()
 	. = ..()
@@ -342,14 +374,63 @@
 	else
 		. += span_notice("It cannot be modified or attached.")
 
+	if(item_flags & IN_INVENTORY && loc == user)
+		// construction of frequency description
+		var/list/avail_chans = list("Use [RADIO_KEY_COMMON] for the currently tuned frequency")
+		if(translate_binary)
+			avail_chans += "use [MODE_TOKEN_BINARY] for [MODE_BINARY]"
+		if(length(channels))
+			for(var/i in 1 to length(channels))
+				if(i == 1)
+					avail_chans += "use [MODE_TOKEN_DEPARTMENT] or [GLOB.channel_tokens[channels[i]]] for [lowertext(channels[i])]"
+				else
+					avail_chans += "use [GLOB.channel_tokens[channels[i]]] for [lowertext(channels[i])]"
+		. += span_notice("A small screen on the [name] displays the following available frequencies:\n[english_list(avail_chans)].")
+
+		if(command)
+			. += span_info("Alt-click to toggle the high-volume mode.")
+	else
+		. += span_notice("A small screen on the [name] flashes, it's too small to read without holding or wearing it.")
+
 /obj/item/radio/attackby(obj/item/W, mob/user, params)
-	add_fingerprint(user)
+	user.set_machine(src)
+
 	if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		unscrewed = !unscrewed
-		if(unscrewed)
-			to_chat(user, span_notice("The radio can now be attached and modified!"))
+		if(keyslot || keyslot2)
+			for(var/ch_name in channels)
+				SSradio.remove_object(src, GLOB.radiochannels[ch_name])
+				secure_radio_connections[ch_name] = null
+
+			if(keyslot)
+				user.put_in_hands(keyslot)
+				keyslot = null
+			if(keyslot2)
+				user.put_in_hands(keyslot2)
+				keyslot2 = null
+
+			recalculateChannels()
+			to_chat(user, span_notice("You pop the encryption keys out of the [name]."))
+
 		else
-			to_chat(user, span_notice("The radio can no longer be modified or attached!"))
+			to_chat(user, span_warning("This [name] doesn't have any unique encryption keys! How useless..."))
+
+	else if(istype(W, /obj/item/encryptionkey))
+		if(keyslot && keyslot2)
+			to_chat(user, span_warning("The [name] can't hold another key!"))
+			return
+
+		if(!keyslot)
+			if(!user.transferItemToLoc(W, src))
+				return
+			keyslot = W
+
+		else
+			if(!user.transferItemToLoc(W, src))
+				return
+			keyslot2 = W
+
+
+		recalculateChannels()
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	icon_state = "walkietalkie"
 	inhand_icon_state = "walkietalkie"
 	worn_icon_state = "radio"
-	desc = "A basic handheld radio that communicates on the station's subspace network."
+	desc = "A basic handheld radio that can communicate on the station's subspace network, or can can transmit messages locally in emergencies."
 	dog_fashion = /datum/dog_fashion/back
 
 	flags_1 = CONDUCT_1
@@ -42,8 +42,8 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	var/prison_radio = FALSE  // If true, the transmit wire starts cut.
 	var/unscrewed = FALSE  // Whether wires are accessible. Toggleable by screwdrivering.
 	var/freerange = FALSE  // If true, the radio has access to the full spectrum.
-	var/subspace_transmission = TRUE  // If true, the radio transmits and receives on subspace exclusively.
-	var/subspace_switchable = FALSE  // If true, subspace_transmission can be toggled at will.
+	var/subspace_transmission = FALSE  // If true, the radio transmits and receives on subspace exclusively.
+	var/subspace_switchable = TRUE  // If true, subspace_transmission can be toggled at will.
 	var/freqlock = FALSE  // Frequency lock to stop the user from untuning specialist radios.
 	var/use_command = FALSE  // If true, broadcasts will be large and BOLD.
 	var/command = FALSE  // If true, use_command can be toggled at will.
@@ -463,8 +463,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/borg
 	name = "cyborg radio"
-	subspace_transmission = TRUE
-	subspace_switchable = TRUE
 	dog_fashion = null
 
 /obj/item/radio/borg/resetChannels()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -412,7 +412,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 			to_chat(user, span_notice("You pop the encryption keys out of the [name]."))
 
 		else
-			to_chat(user, span_warning("This [name] doesn't have any unique encryption keys! How useless..."))
+			to_chat(user, span_warning("This [name] doesn't have any encryption keys installed!"))
 
 	else if(istype(W, /obj/item/encryptionkey))
 		if(keyslot && keyslot2)
@@ -481,39 +481,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 /obj/item/radio/borg/syndicate/Initialize()
 	. = ..()
 	set_frequency(FREQ_SYNDICATE)
-
-/obj/item/radio/borg/attackby(obj/item/W, mob/user, params)
-
-	if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(keyslot)
-			for(var/ch_name in channels)
-				SSradio.remove_object(src, GLOB.radiochannels[ch_name])
-				secure_radio_connections[ch_name] = null
-
-
-			if(keyslot)
-				var/turf/T = get_turf(user)
-				if(T)
-					keyslot.forceMove(T)
-					keyslot = null
-
-			recalculateChannels()
-			to_chat(user, span_notice("You pop out the encryption key in the radio."))
-
-		else
-			to_chat(user, span_warning("This radio doesn't have any encryption keys!"))
-
-	else if(istype(W, /obj/item/encryptionkey/))
-		if(keyslot)
-			to_chat(user, span_warning("The radio can't hold another key!"))
-			return
-
-		if(!keyslot)
-			if(!user.transferItemToLoc(W, src))
-				return
-			keyslot = W
-
-		recalculateChannels()
 
 
 /obj/item/radio/off // Station bounced radios, their only difference is spawning with the speakers off, this was made to help the lag.

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -464,6 +464,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 /obj/item/radio/borg
 	name = "cyborg radio"
 	dog_fashion = null
+	subspace_transmission = TRUE
 
 /obj/item/radio/borg/resetChannels()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -69,18 +69,27 @@
 	if(message_mods[MODE_HEADSET])
 		if(ears)
 			ears.talk_into(src, message, , spans, language, message_mods)
+		for(var/obj/item/radio/held in held_items)
+			if(held)
+				held.talk_into(src, message, , spans, language, message_mods)
 		return ITALICS | REDUCE_RANGE
 	else if(message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT)
 		if(ears)
 			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+		for(var/obj/item/radio/held in held_items)
+			if(held)
+				held.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 		return ITALICS | REDUCE_RANGE
 	else if(GLOB.radiochannels[message_mods[RADIO_EXTENSION]])
 		if(ears)
 			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-			return ITALICS | REDUCE_RANGE
+		for(var/obj/item/radio/held in held_items)
+			if(held)
+				held.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+		return ITALICS | REDUCE_RANGE
 
-	return FALSE
+	return FALSE;
 
 /mob/living/carbon/human/get_alt_name()
 	if(name != GetVoice())
-		return " (as [get_id_name("Unknown")])"\
+		return " (as [get_id_name("Unknown")])"

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -88,7 +88,7 @@
 				held.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 		return ITALICS | REDUCE_RANGE
 
-	return FALSE;
+	return FALSE
 
 /mob/living/carbon/human/get_alt_name()
 	if(name != GetVoice())


### PR DESCRIPTION
## About The Pull Request

This PR allows station-bounced radios to broadcast messages on the subspace network (making them no longer station-bounced radios), allows encryption keys to be installed into them, and allows speaking into radios held in your hand without turning on the microphone.

## Why It's Good For The Game

This makes hand radios more than a toy, and also introduces them as a potential viable alternative to headsets, for cosmetic purposes.

## Changelog
:cl:
add: Allows radios to be spoken into when in hand without their microphones being enabled
expansion: Station-bounced radios now communicate on subspace network, can have encryption keys added and removed
del: hand radios can no longer be attached to things, though afaik they couldn't be used for grenades or TTVs anyway
code: combined a lot of headset code with radio code
code: hands are now checked for radios whenever a human attempts to say something into a radio channel
/:cl:
