### PR TITLE
Fixes eye cybernetics sometimes not working when installed in the wrong order, also adds NT cyberlink autosurgeon to CMO's office

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -96,6 +96,7 @@
 	new /obj/item/circuitboard/machine/techfab/department/medical(src)
 	new /obj/item/storage/photo_album/cmo(src)
 	new /obj/item/clothing/suit/hooded/wintercoat/medical/cmo(src)
+	new /obj/item/autosurgeon/organ/cyberlink_nt_low(src)
 
 /obj/structure/closet/secure_closet/animal
 	name = "animal control"

--- a/code/modules/surgery/organs/cybernetics/augments_eyes.dm
+++ b/code/modules/surgery/organs/cybernetics/augments_eyes.dm
@@ -27,9 +27,9 @@
 		return
 	if(HUD_type)
 		var/datum/atom_hud/H = GLOB.huds[HUD_type]
-		H.add_hud_to(M)
+		H.add_hud_to(owner)
 	if(HUD_trait)
-		ADD_TRAIT(M, HUD_trait, ORGAN_TRAIT)
+		ADD_TRAIT(owner, HUD_trait, ORGAN_TRAIT)
 
 /obj/item/organ/cyberimp/eyes/hud/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = FALSE)
 	..()

--- a/code/modules/surgery/organs/cybernetics/augments_eyes.dm
+++ b/code/modules/surgery/organs/cybernetics/augments_eyes.dm
@@ -18,13 +18,18 @@
 
 /obj/item/organ/cyberimp/eyes/hud/update_implants()
 	. = ..()
-	if(check_compatibility())
+	if(!check_compatibility())
+		if(HUD_type)
+			var/datum/atom_hud/H = GLOB.huds[HUD_type]
+			H.remove_hud_from(owner)
+		if(HUD_trait)
+			REMOVE_TRAIT(owner, HUD_trait, ORGAN_TRAIT)
 		return
 	if(HUD_type)
 		var/datum/atom_hud/H = GLOB.huds[HUD_type]
-		H.remove_hud_from(owner)
+		H.add_hud_to(M)
 	if(HUD_trait)
-		REMOVE_TRAIT(owner, HUD_trait, ORGAN_TRAIT)
+		ADD_TRAIT(M, HUD_trait, ORGAN_TRAIT)
 
 /obj/item/organ/cyberimp/eyes/hud/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = FALSE)
 	..()


### PR DESCRIPTION
## About The Pull Request
Eyes didnt have proper update logic in em. 
Also adds NT1.0 cyberlink autosurgeon to CMO's office

## Changelog
:cl:
fix: Fixed eye implant auto-update logic
add: CMO's locker now spawns with NT1.0 cyberlink autosurgeon
/:cl:
