### PR TITLE
Radio Encryption Key Refactor

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -276,7 +276,7 @@
 /obj/item/bounty_cube/Initialize()
 	. = ..()
 	radio = new(src)
-	radio.keyslot = new radio_key
+	radio.keyslots += new radio_key
 	radio.listening = FALSE
 	radio.recalculateChannels()
 

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -278,6 +278,7 @@
 	radio = new(src)
 	radio.keyslots += new radio_key
 	radio.listening = FALSE
+	radio.subspace_transmission = FALSE
 	radio.recalculateChannels()
 
 /obj/item/bounty_cube/Destroy()

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -6,6 +6,7 @@
 	worn_icon_state = null
 	custom_materials = list(/datum/material/iron=75)
 	canhear_range = 0 // can't hear headsets from very far away
+	max_keyslots = 2
 	subspace_switchable = FALSE
 	subspace_transmission = TRUE
 
@@ -57,15 +58,14 @@
 /obj/item/radio/headset/binary
 /obj/item/radio/headset/binary/Initialize()
 	. = ..()
-	qdel(keyslot)
-	keyslot = new /obj/item/encryptionkey/binary
+	keyslots += new /obj/item/encryptionkey/binary
 	recalculateChannels()
 
 /obj/item/radio/headset/headset_sec
 	name = "security radio headset"
 	desc = "This is used by your elite security force."
 	icon_state = "sec_headset"
-	keyslot = new /obj/item/encryptionkey/headset_sec
+	keyslots = list(new /obj/item/encryptionkey/headset_sec)
 
 /obj/item/radio/headset/headset_sec/alt
 	name = "security bowman headset"
@@ -81,49 +81,49 @@
 	name = "engineering radio headset"
 	desc = "When the engineers wish to chat like girls."
 	icon_state = "eng_headset"
-	keyslot = new /obj/item/encryptionkey/headset_eng
+	keyslots = list(new /obj/item/encryptionkey/headset_eng)
 
 /obj/item/radio/headset/headset_rob
 	name = "robotics radio headset"
 	desc = "Made specifically for the roboticists, who cannot decide between departments."
 	icon_state = "rob_headset"
-	keyslot = new /obj/item/encryptionkey/headset_rob
+	keyslots = list(new /obj/item/encryptionkey/headset_rob)
 
 /obj/item/radio/headset/headset_med
 	name = "medical radio headset"
 	desc = "A headset for the trained staff of the medbay."
 	icon_state = "med_headset"
-	keyslot = new /obj/item/encryptionkey/headset_med
+	keyslots = list(new /obj/item/encryptionkey/headset_med)
 
 /obj/item/radio/headset/headset_sci
 	name = "science radio headset"
 	desc = "A sciency headset. Like usual."
 	icon_state = "sci_headset"
-	keyslot = new /obj/item/encryptionkey/headset_sci
+	keyslots = list(new /obj/item/encryptionkey/headset_sci)
 
 /obj/item/radio/headset/headset_medsci
 	name = "medical research radio headset"
 	desc = "A headset that is a result of the mating between medical and science."
 	icon_state = "medsci_headset"
-	keyslot = new /obj/item/encryptionkey/headset_medsci
+	keyslots = list(new /obj/item/encryptionkey/headset_medsci)
 
 /obj/item/radio/headset/headset_srvsec
 	name = "law and order headset"
 	desc = "In the criminal justice headset, the encryption key represents two separate but equally important groups. Sec, who investigate crime, and Service, who provide services. These are their comms."
 	icon_state = "srvsec_headset"
-	keyslot = new /obj/item/encryptionkey/headset_srvsec
+	keyslots = list(new /obj/item/encryptionkey/headset_srvsec)
 
 /obj/item/radio/headset/headset_srvmed
 	name = "psychology headset"
 	desc = "A headset allowing the wearer to communicate with medbay and service."
 	icon_state = "med_headset"
-	keyslot = new /obj/item/encryptionkey/headset_srvmed
+	keyslots = list(new /obj/item/encryptionkey/headset_srvmed)
 
 /obj/item/radio/headset/headset_com
 	name = "command radio headset"
 	desc = "A headset with a commanding channel."
 	icon_state = "com_headset"
-	keyslot = new /obj/item/encryptionkey/headset_com
+	keyslots = list(new /obj/item/encryptionkey/headset_com)
 
 /obj/item/radio/headset/heads
 	command = TRUE
@@ -132,7 +132,7 @@
 	name = "\proper the captain's headset"
 	desc = "The headset of the king."
 	icon_state = "com_headset"
-	keyslot = new /obj/item/encryptionkey/heads/captain
+	keyslots = list(new /obj/item/encryptionkey/heads/captain)
 
 /obj/item/radio/headset/heads/captain/alt
 	name = "\proper the captain's bowman headset"
@@ -148,13 +148,13 @@
 	name = "\proper the research director's headset"
 	desc = "Headset of the fellow who keeps society marching towards technological singularity."
 	icon_state = "com_headset"
-	keyslot = new /obj/item/encryptionkey/heads/rd
+	keyslots = list(new /obj/item/encryptionkey/heads/rd)
 
 /obj/item/radio/headset/heads/hos
 	name = "\proper the head of security's headset"
 	desc = "The headset of the man in charge of keeping order and protecting the station."
 	icon_state = "com_headset"
-	keyslot = new /obj/item/encryptionkey/heads/hos
+	keyslots = list(new /obj/item/encryptionkey/heads/hos)
 
 /obj/item/radio/headset/heads/hos/alt
 	name = "\proper the head of security's bowman headset"
@@ -170,58 +170,56 @@
 	name = "\proper the chief engineer's headset"
 	desc = "The headset of the guy in charge of keeping the station powered and undamaged."
 	icon_state = "com_headset"
-	keyslot = new /obj/item/encryptionkey/heads/ce
+	keyslots = list(new /obj/item/encryptionkey/heads/ce)
 
 /obj/item/radio/headset/heads/cmo
 	name = "\proper the chief medical officer's headset"
 	desc = "The headset of the highly trained medical chief."
 	icon_state = "com_headset"
-	keyslot = new /obj/item/encryptionkey/heads/cmo
+	keyslots = list(new /obj/item/encryptionkey/heads/cmo)
 
 /obj/item/radio/headset/heads/hop
 	name = "\proper the head of personnel's headset"
 	desc = "The headset of the guy who will one day be captain."
 	icon_state = "com_headset"
-	keyslot = new /obj/item/encryptionkey/heads/hop
+	keyslots = list(new /obj/item/encryptionkey/heads/hop)
 
 /obj/item/radio/headset/headset_cargo
 	name = "supply radio headset"
 	desc = "A headset used by the QM and his slaves."
 	icon_state = "cargo_headset"
-	keyslot = new /obj/item/encryptionkey/headset_cargo
+	keyslots = list(new /obj/item/encryptionkey/headset_cargo)
 
 /obj/item/radio/headset/headset_cargo/mining
 	name = "mining radio headset"
 	desc = "Headset used by shaft miners."
 	icon_state = "mine_headset"
-	keyslot = new /obj/item/encryptionkey/headset_mining
+	keyslots = list(new /obj/item/encryptionkey/headset_mining)
 
 /obj/item/radio/headset/headset_srv
 	name = "service radio headset"
 	desc = "Headset used by the service staff, tasked with keeping the station full, happy and clean."
 	icon_state = "srv_headset"
-	keyslot = new /obj/item/encryptionkey/headset_service
+	keyslots = list(new /obj/item/encryptionkey/headset_service)
 
 /obj/item/radio/headset/headset_cent
 	name = "\improper CentCom headset"
 	desc = "A headset used by the upper echelons of Nanotrasen."
 	icon_state = "cent_headset"
-	keyslot = new /obj/item/encryptionkey/headset_com
-	keyslot2 = new /obj/item/encryptionkey/headset_cent
+	keyslots = list(new /obj/item/encryptionkey/headset_com, new /obj/item/encryptionkey/headset_cent)
 
 /obj/item/radio/headset/headset_cent/empty
-	keyslot = null
-	keyslot2 = null
+	keyslots = list()
 
 /obj/item/radio/headset/headset_cent/commander
-	keyslot = new /obj/item/encryptionkey/heads/captain
+	keyslots = list(new /obj/item/encryptionkey/heads/captain)
 
 /obj/item/radio/headset/headset_cent/alt
 	name = "\improper CentCom bowman headset"
 	desc = "A headset especially for emergency response personnel. Protects ears from flashbangs."
 	icon_state = "cent_headset_alt"
 	inhand_icon_state = "cent_headset_alt"
-	keyslot = null
+	keyslots = list()
 
 /obj/item/radio/headset/headset_cent/alt/ComponentInitialize()
 	. = ..()
@@ -234,7 +232,7 @@
 
 /obj/item/radio/headset/silicon/ai
 	name = "\proper Integrated Subspace Transceiver "
-	keyslot2 = new /obj/item/encryptionkey/ai
+	keyslots = list(new /obj/item/encryptionkey/ai)
 	command = TRUE
 
 /obj/item/radio/headset/silicon/can_receive(freq, level)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -57,7 +57,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	var/independent = FALSE  // If true, can say/hear on the special CentCom channel.
 	var/syndie = FALSE  // If true, hears all well-known channels automatically, and can say/hear on the Syndicate channel.
 	var/list/channels = list()  // Map from name (see communications.dm) to on/off. First entry is current department (:h)
-	var/list/keyslots = list()
+	var/list/obj/item/encryptionkey/keyslots = list()
 	var/list/secure_radio_connections
 
 /obj/item/radio/suicide_act(mob/living/user)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -101,8 +101,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 /obj/item/radio/Destroy()
 	remove_radio_all(src) //Just to be sure
 	QDEL_NULL(wires)
-	for (var/K in keyslots)
-		QDEL_NULL(K)
+	QDEL_LIST(keyslots)
 
 	return ..()
 

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -72,7 +72,7 @@
 	radio.subspace_transmission = subspace_transmission
 	radio.canhear_range = 0
 	if(radio_key)
-		radio.keyslot = new radio_key
+		radio.keyslots += new radio_key
 	radio.recalculateChannels()
 
 /obj/item/implant/radio/Destroy()

--- a/code/modules/admin/verbs/borgpanel.dm
+++ b/code/modules/admin/verbs/borgpanel.dm
@@ -177,7 +177,7 @@
 				log_admin("[key_name(user)] removed the [channel] radio channel from [key_name(borg)].")
 			else // We're adding a channel
 				if (!borg.radio.keyslots.len) // Assert that an encryption key exists
-					borg.radio.keyslots += new /obj/item/radio/borg
+					borg.radio.keyslots += new /obj/item/encryptionkey
 				borg.radio.keyslots[1].channels[channel] = 1
 				if (channel == RADIO_CHANNEL_SYNDICATE)
 					borg.radio.keyslots[1].syndie = TRUE

--- a/code/modules/admin/verbs/borgpanel.dm
+++ b/code/modules/admin/verbs/borgpanel.dm
@@ -177,7 +177,7 @@
 				log_admin("[key_name(user)] removed the [channel] radio channel from [key_name(borg)].")
 			else // We're adding a channel
 				if (!borg.radio.keyslots.len) // Assert that an encryption key exists
-					borg.radio.keyslots += new (borg.radio)
+					borg.radio.keyslots += new /obj/item/radio/borg
 				borg.radio.keyslots[1].channels[channel] = 1
 				if (channel == RADIO_CHANNEL_SYNDICATE)
 					borg.radio.keyslots[1].syndie = TRUE

--- a/code/modules/admin/verbs/borgpanel.dm
+++ b/code/modules/admin/verbs/borgpanel.dm
@@ -161,28 +161,28 @@
 		if ("toggle_radio")
 			var/channel = params["channel"]
 			if (channel in borg.radio.channels) // We're removing a channel
-				if (!borg.radio.keyslot) // There's no encryption key. This shouldn't happen but we can cope
+				if (!borg.radio.keyslots.len) // There's no encryption key. This shouldn't happen but we can cope
 					borg.radio.channels -= channel
 					if (channel == RADIO_CHANNEL_SYNDICATE)
 						borg.radio.syndie = FALSE
 					else if (channel == "CentCom")
 						borg.radio.independent = FALSE
 				else
-					borg.radio.keyslot.channels -= channel
+					borg.radio.keyslots[1].channels -= channel
 					if (channel == RADIO_CHANNEL_SYNDICATE)
-						borg.radio.keyslot.syndie = FALSE
+						borg.radio.keyslots[1].syndie = FALSE
 					else if (channel == "CentCom")
-						borg.radio.keyslot.independent = FALSE
+						borg.radio.keyslots[1].independent = FALSE
 				message_admins("[key_name_admin(user)] removed the [channel] radio channel from [ADMIN_LOOKUPFLW(borg)].")
 				log_admin("[key_name(user)] removed the [channel] radio channel from [key_name(borg)].")
 			else // We're adding a channel
-				if (!borg.radio.keyslot) // Assert that an encryption key exists
-					borg.radio.keyslot = new (borg.radio)
-				borg.radio.keyslot.channels[channel] = 1
+				if (!borg.radio.keyslots.len) // Assert that an encryption key exists
+					borg.radio.keyslots += new (borg.radio)
+				borg.radio.keyslots[1].channels[channel] = 1
 				if (channel == RADIO_CHANNEL_SYNDICATE)
-					borg.radio.keyslot.syndie = TRUE
+					borg.radio.keyslots[1].syndie = TRUE
 				else if (channel == "CentCom")
-					borg.radio.keyslot.independent = TRUE
+					borg.radio.keyslots[1].independent = TRUE
 				message_admins("[key_name_admin(user)] added the [channel] radio channel to [ADMIN_LOOKUPFLW(borg)].")
 				log_admin("[key_name(user)] added the [channel] radio channel to [key_name(borg)].")
 			borg.radio.recalculateChannels()

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -665,7 +665,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "abductor_headset"
 	inhand_icon_state = "abductor_headset"
-	keyslot2 = new /obj/item/encryptionkey/heads/captain
+	keyslots = list(new /obj/item/encryptionkey/heads/captain)
 
 /obj/item/radio/headset/abductor/Initialize(mapload)
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
@@ -153,7 +153,7 @@
 	moderator_internal.volume = 10000
 
 	radio = new(src)
-	radio.keyslot = new radio_key
+	radio.keyslots += new radio_key
 	radio.listening = 0
 	radio.recalculateChannels()
 	investigate_log("has been created.", INVESTIGATE_HYPERTORUS)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
@@ -154,7 +154,8 @@
 
 	radio = new(src)
 	radio.keyslots += new radio_key
-	radio.listening = 0
+	radio.listening = FALSE
+	radio.subspace_transmission = FALSE
 	radio.recalculateChannels()
 	investigate_log("has been created.", INVESTIGATE_HYPERTORUS)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -113,7 +113,7 @@
 		begin_processing()
 
 	radio = new(src)
-	radio.keyslot = new radio_key
+	radio.keyslots += new radio_key
 	radio.subspace_transmission = TRUE
 	radio.canhear_range = 0
 	radio.recalculateChannels()

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -114,7 +114,6 @@
 
 	radio = new(src)
 	radio.keyslots += new radio_key
-	radio.subspace_transmission = TRUE
 	radio.canhear_range = 0
 	radio.recalculateChannels()
 

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -53,7 +53,7 @@
 	if(visualsOnly)
 		return
 	var/obj/item/radio/R = H.ears
-	R.keyslot = new /obj/item/encryptionkey/heads/captain
+	R.keyslots += new /obj/item/encryptionkey/heads/captain
 	R.recalculateChannels()
 
 /datum/outfit/centcom/ert/commander/alert
@@ -90,7 +90,7 @@
 		return
 
 	var/obj/item/radio/R = H.ears
-	R.keyslot = new /obj/item/encryptionkey/heads/hos
+	R.keyslots += new /obj/item/encryptionkey/heads/hos
 	R.recalculateChannels()
 
 /datum/outfit/centcom/ert/security/alert
@@ -129,7 +129,7 @@
 		return
 
 	var/obj/item/radio/R = H.ears
-	R.keyslot = new /obj/item/encryptionkey/heads/cmo
+	R.keyslots += new /obj/item/encryptionkey/heads/cmo
 	R.recalculateChannels()
 
 /datum/outfit/centcom/ert/medic/alert
@@ -169,7 +169,7 @@
 		return
 
 	var/obj/item/radio/R = H.ears
-	R.keyslot = new /obj/item/encryptionkey/heads/ce
+	R.keyslots += new /obj/item/encryptionkey/heads/ce
 	R.recalculateChannels()
 
 /datum/outfit/centcom/ert/engineer/alert
@@ -269,7 +269,7 @@
 	if(visualsOnly)
 		return
 	var/obj/item/radio/R = H.ears
-	R.keyslot = new /obj/item/encryptionkey/heads/hop
+	R.keyslots += new /obj/item/encryptionkey/heads/hop
 	R.recalculateChannels()
 
 /datum/outfit/centcom/ert/chaplain/inquisitor
@@ -309,7 +309,7 @@
 		return
 
 	var/obj/item/radio/R = H.ears
-	R.keyslot = new /obj/item/encryptionkey/headset_service
+	R.keyslots += new /obj/item/encryptionkey/headset_service
 	R.recalculateChannels()
 
 /datum/outfit/centcom/ert/janitor/heavy
@@ -347,7 +347,7 @@
 	if(visualsOnly)
 		return
 	var/obj/item/radio/R = H.ears
-	R.keyslot = new /obj/item/encryptionkey/headset_service
+	R.keyslots += new /obj/item/encryptionkey/headset_service
 	R.recalculateChannels()
 	ADD_TRAIT(H, TRAIT_NAIVE, INNATE_TRAIT)
 	H.dna.add_mutation(CLOWNMUT)
@@ -560,7 +560,7 @@
 	if(visualsOnly)
 		return
 	var/obj/item/radio/headset = equipper.ears
-	headset.keyslot = new /obj/item/encryptionkey/heads/captain
+	headset.keyslots += new /obj/item/encryptionkey/heads/captain
 	headset.recalculateChannels()
 
 /datum/outfit/centcom/ert/marine/security
@@ -580,7 +580,7 @@
 		return
 
 	var/obj/item/radio/headset = equipper.ears
-	headset.keyslot = new /obj/item/encryptionkey/heads/hos
+	headset.keyslots += new /obj/item/encryptionkey/heads/hos
 	headset.recalculateChannels()
 
 /datum/outfit/centcom/ert/marine/medic
@@ -609,7 +609,7 @@
 		return
 
 	var/obj/item/radio/headset = equipper.ears
-	headset.keyslot = new /obj/item/encryptionkey/heads/cmo
+	headset.keyslots += new /obj/item/encryptionkey/heads/cmo
 	headset.recalculateChannels()
 
 /datum/outfit/centcom/ert/marine/engineer
@@ -639,5 +639,5 @@
 		return
 
 	var/obj/item/radio/headset = equipper.ears
-	headset.keyslot = new /obj/item/encryptionkey/heads/ce
+	headset.keyslots += new /obj/item/encryptionkey/heads/ce
 	headset.recalculateChannels()

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -220,20 +220,16 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	recalculateChannels()
 
 /obj/item/radio/headset/headset_sec/alt/department/engi
-	keyslot = new /obj/item/encryptionkey/headset_sec
-	keyslot2 = new /obj/item/encryptionkey/headset_eng
+	keyslots = list(new /obj/item/encryptionkey/headset_sec, new /obj/item/encryptionkey/headset_eng)
 
 /obj/item/radio/headset/headset_sec/alt/department/supply
-	keyslot = new /obj/item/encryptionkey/headset_sec
-	keyslot2 = new /obj/item/encryptionkey/headset_cargo
+	keyslots = list(new /obj/item/encryptionkey/headset_sec, new /obj/item/encryptionkey/headset_cargo)
 
 /obj/item/radio/headset/headset_sec/alt/department/med
-	keyslot = new /obj/item/encryptionkey/headset_sec
-	keyslot2 = new /obj/item/encryptionkey/headset_med
+	keyslots = list(new /obj/item/encryptionkey/headset_sec, new /obj/item/encryptionkey/headset_med)
 
 /obj/item/radio/headset/headset_sec/alt/department/sci
-	keyslot = new /obj/item/encryptionkey/headset_sec
-	keyslot2 = new /obj/item/encryptionkey/headset_sci
+	keyslots = list(new /obj/item/encryptionkey/headset_sec, new /obj/item/encryptionkey/headset_sci)
 
 /// Returns the distribution of splitting the given security officers into departments.
 /// Return value is an assoc list of candidate => SEC_DEPT_*.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -108,9 +108,10 @@
 	if(shell)
 		GLOB.available_ai_shells -= src
 	else
-		if(T && istype(radio) && istype(radio.keyslot))
-			radio.keyslot.forceMove(T)
-			radio.keyslot = null
+		if(T && istype(radio) && radio.keyslots.len)
+			for (var/atom/movable/K in radio.keyslots)
+				K.forceMove(T)
+				radio.keyslots -= K
 	QDEL_NULL(wires)
 	QDEL_NULL(model)
 	QDEL_NULL(eye_lights)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -161,7 +161,7 @@
 	set_custom_texts()
 	Radio = new/obj/item/radio(src)
 	if(radio_key)
-		Radio.keyslot = new radio_key
+		Radio.keyslots += new radio_key
 	Radio.subspace_transmission = TRUE
 	Radio.canhear_range = 0 // anything greater will have the bot broadcast the channel as if it were saying it out loud.
 	Radio.recalculateChannels()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -162,7 +162,6 @@
 	Radio = new/obj/item/radio(src)
 	if(radio_key)
 		Radio.keyslots += new radio_key
-	Radio.subspace_transmission = TRUE
 	Radio.canhear_range = 0 // anything greater will have the bot broadcast the channel as if it were saying it out loud.
 	Radio.recalculateChannels()
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -232,7 +232,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	countdown.start()
 	AddElement(/datum/element/point_of_interest)
 	radio = new(src)
-	radio.keyslot = new radio_key
+	radio.keyslots += new radio_key
 	radio.listening = 0
 	radio.recalculateChannels()
 	investigate_log("has been created.", INVESTIGATE_SUPERMATTER)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -233,7 +233,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	AddElement(/datum/element/point_of_interest)
 	radio = new(src)
 	radio.keyslots += new radio_key
-	radio.listening = 0
+	radio.listening = FALSE
+	radio.subspace_transmission = FALSE
 	radio.recalculateChannels()
 	investigate_log("has been created.", INVESTIGATE_SUPERMATTER)
 	if(is_main_engine)


### PR DESCRIPTION
## About The Pull Request

Replaces the keyslot and keyslot2 variables in radios with a list called keyslots. Also makes all radios only accept one encryption key by default (as opposed to the 0 that was allowed before my previous PR).

## Why It's Good For The Game

Makes the code for adding and removing encryption keys from a radio/headset much cleaner, and can scale to allow for radios with more (or less) maximum allowed encryption keys.

## Changelog
:cl:
refactor: replaced keyslot and keyslot2 vars with keyslots list
balance: made radios accept only 1 encryption key by default (except for headsets)
/:cl:
