### PR TITLE
Add syndicate cigarettes to the contraband of cigarette vending machines

### DIFF
--- a/code/modules/vending/cigarette.dm
+++ b/code/modules/vending/cigarette.dm
@@ -13,7 +13,8 @@
 					/obj/item/storage/box/matches = 10,
 					/obj/item/lighter/greyscale = 4,
 					/obj/item/storage/fancy/rollingpapers = 5)
-	contraband = list(/obj/item/clothing/mask/vape = 5)
+	contraband = list(/obj/item/clothing/mask/vape = 5,
+					/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 3)
 	premium = list(/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 3,
 				   /obj/item/storage/box/gum/nicotine = 2,
 				   /obj/item/lighter = 3,


### PR DESCRIPTION
## About The Pull Request

Adds syndicate cigarette packets to the contraband catalogue of cigarette vending machines (vending machines must be hacked in order to show these cigarettes available for sale).

![syndie-cigs](https://user-images.githubusercontent.com/34369281/164970218-0c22ab7d-d23b-436f-ae81-a6aca4cef5bb.png)

## Why It's Good For The Game

It's cool. (Omnizine is readily available anyways through donk pockets anyways).

## Changelog
:cl:
add: Adds syndicate cigarette packets to the contraband catalogue of cigarette vending machines.
/:cl:
