### PR TITLE
Remove redundant check for talking into radios held in hand

### DIFF
--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -69,19 +69,19 @@
 	if(message_mods[MODE_HEADSET])
 		if(ears)
 			ears.talk_into(src, message, , spans, language, message_mods)
-		for(var/obj/item/radio/held in held_items)
+		for(var/obj/item/held in held_items)
 			held.talk_into(src, message, , spans, language, message_mods)
 		return ITALICS | REDUCE_RANGE
 	else if(message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT)
 		if(ears)
 			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-		for(var/obj/item/radio/held in held_items)
+		for(var/obj/item/held in held_items)
 			held.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 		return ITALICS | REDUCE_RANGE
 	else if(GLOB.radiochannels[message_mods[RADIO_EXTENSION]])
 		if(ears)
 			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-		for(var/obj/item/radio/held in held_items)
+		for(var/obj/item/held in held_items)
 			held.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 		return ITALICS | REDUCE_RANGE
 

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -70,22 +70,19 @@
 		if(ears)
 			ears.talk_into(src, message, , spans, language, message_mods)
 		for(var/obj/item/radio/held in held_items)
-			if(held)
-				held.talk_into(src, message, , spans, language, message_mods)
+			held.talk_into(src, message, , spans, language, message_mods)
 		return ITALICS | REDUCE_RANGE
 	else if(message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT)
 		if(ears)
 			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 		for(var/obj/item/radio/held in held_items)
-			if(held)
-				held.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+			held.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 		return ITALICS | REDUCE_RANGE
 	else if(GLOB.radiochannels[message_mods[RADIO_EXTENSION]])
 		if(ears)
 			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 		for(var/obj/item/radio/held in held_items)
-			if(held)
-				held.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+			held.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 		return ITALICS | REDUCE_RANGE
 
 	return FALSE


### PR DESCRIPTION
The lines that are removed `if(held)` are redundant, because `for(var/obj/item/radio/held in held_items)` already typechecks the object being iterated.

These changes don't conflict with the one in the other radio refactoring PR.

## Changelog
:cl:
refactor: Remove redundant check for talking into radios held in hand
/:cl:
