### PR TITLE
Readds the CentCom encryption key to ERT headsets

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -212,14 +212,14 @@
 	keyslots = list()
 
 /obj/item/radio/headset/headset_cent/commander
-	keyslots = list(new /obj/item/encryptionkey/heads/captain)
+	keyslots = list(new /obj/item/encryptionkey/heads/captain, new /obj/item/encryptionkey/headset_cent)
 
 /obj/item/radio/headset/headset_cent/alt
 	name = "\improper CentCom bowman headset"
 	desc = "A headset especially for emergency response personnel. Protects ears from flashbangs."
 	icon_state = "cent_headset_alt"
 	inhand_icon_state = "cent_headset_alt"
-	keyslots = list()
+	keyslots = list(new /obj/item/encryptionkey/headset_cent)
 
 /obj/item/radio/headset/headset_cent/alt/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Fixes the initialization of ERT headsets to have the CentCom encryption key, which was accidentally removed in the previous refactor PR.

## Changelog
:cl:
fix: Readds the CentCom encryption key to ERT headsets
/:cl:
