### PR TITLE
Increase wrestle belt tc cost

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2147,7 +2147,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Wrestling Set"
 	desc = "OH YEAH BROTHERRRR!"
 	item = /obj/item/storage/box/syndie_kit/wrestling
-	cost = 8 //The wrestling set is not as powerful as it once was
+	cost = 17 //The wrestling set is not as powerful as it once was (BULLSHIT)
 	purchasable_from = UPLINK_TRAITORS
 
 /datum/uplink_item/dangerous/armstrong


### PR DESCRIPTION
## About The Pull Request
Increases the price of the traitor uplink wrestling belt to 17 tc
## Why It's Good For The Game
Instant aggro grab, old stuns and you can still use guns. This used to be a tc trade for a reason and if we're going to put it in the uplink then it's going to cost at least as much as old sleeping carp.
## Changelog
The belt now costs 17 tc instead of a insanely low 8 tc
