### PR TITLE
Downgraded node dependency to match RL8 package

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -12,7 +12,7 @@ export RUST_G_VERSION=0.6.0
 
 #node version
 export NODE_VERSION=16
-export NODE_VERSION_PRECISE=16.14.2
+export NODE_VERSION_PRECISE=16.13.1
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.7.2


### PR DESCRIPTION
## About The Pull Request

Downgrades the node.js dependency from 16.14 to 16.13, which is the latest version Rocky Linux 8 is compatible with.

## Why It's Good For The Game

The server works again.

## Changelog
:cl:
fix: Downgraded node dependency to match RL8 package (16.14.2 -> 16.13.1)
/:cl:
