### PR TITLE
Adds SSL Support for the server's MariaDB Database

### DIFF
--- a/code/controllers/configuration/entries/dbconfig.dm
+++ b/code/controllers/configuration/entries/dbconfig.dm
@@ -15,6 +15,12 @@
 	default = "test"
 	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
 
+/datum/config_entry/number/feedback_ssl
+	default = 0
+	min_val = 0
+	max_val = 1
+	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
+
 /datum/config_entry/string/feedback_login
 	default = "root"
 	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -212,6 +212,7 @@ SUBSYSTEM_DEF(dbcore)
 	var/user = CONFIG_GET(string/feedback_login)
 	var/pass = CONFIG_GET(string/feedback_password)
 	var/db = CONFIG_GET(string/feedback_database)
+	var/ssl = CONFIG_GET(number/feedback_ssl)
 	var/address = CONFIG_GET(string/address)
 	var/port = CONFIG_GET(number/port)
 	var/timeout = max(CONFIG_GET(number/async_query_timeout), CONFIG_GET(number/blocking_query_timeout))
@@ -225,6 +226,7 @@ SUBSYSTEM_DEF(dbcore)
 		"user" = user,
 		"pass" = pass,
 		"db_name" = db,
+		"db_ssl" = ssl,
 		"read_timeout" = timeout,
 		"write_timeout" = timeout,
 		"max_threads" = thread_limit,

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -15,6 +15,9 @@ PORT 3306
 ## Database for all SQL functions, not just feedback.
 FEEDBACK_DATABASE feedback
 
+## Enables or Disables SSL for the MariaDB database
+FEEDBACK_SSL 0
+
 ## Prefix to be added to the name of every table, older databases will require this be set to erro_
 ## Note, this does not change the table names in the database, you will have to do that yourself.
 ##IE:

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -8,7 +8,7 @@ export BYOND_MAJOR=514
 export BYOND_MINOR=1583
 
 #rust_g git tag
-export RUST_G_VERSION=0.6.0
+export RUST_G_VERSION=0.7.1
 
 #node version
 export NODE_VERSION=16


### PR DESCRIPTION
## About The Pull Request

Allows the server to encrypt SQL queries in TLS, making communication between the game server and SQL server over the internet more secure

## Changelog
:cl:
add: Added MariaDB TLS support
/:cl:
