### PR TITLE
Updates Node LTS again to latest version

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -12,7 +12,7 @@ export RUST_G_VERSION=0.7.3
 
 #node version
 export NODE_VERSION=16
-export NODE_VERSION_PRECISE=16.13.1
+export NODE_VERSION_PRECISE=16.15.0
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.7.2


### PR DESCRIPTION
## About The Pull Request

TGS gets its own version of node when compiling, so we're not held back by whatever version Rocky Linux officially supports

## Changelog
:cl:
server: Updates Node LTS again to latest version
/:cl:
