### PR TITLE
Changed config URLs to use merchant station links [ci skip]

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -217,16 +217,16 @@
 /datum/config_entry/string/banappeals
 
 /datum/config_entry/string/wikiurl
-	default = "http://www.tgstation13.org/wiki"
+	default = "http://wiki.merchantstation.net/"
 
 /datum/config_entry/string/discordurl
-	default = ""
+	default = "https://discord.gg/2YYfU3ZanD"
 
 /datum/config_entry/string/rulesurl
-	default = "http://www.tgstation13.org/wiki/Rules"
+	default = "http://wiki.merchantstation.net/wiki/Rules"
 
 /datum/config_entry/string/githuburl
-	default = "https://www.github.com/tgstation/tgstation"
+	default = "https://www.github.com/The-Merchants-Guild/Merchant-Station-13"
 
 /datum/config_entry/string/discordbotcommandprefix
 	default = "?"

--- a/config/config.txt
+++ b/config/config.txt
@@ -239,13 +239,13 @@ WEBCLIENT_ONLY_BYOND_MEMBERS
 # FORUMURL http://tgstation13.org/phpBB/index.php
 
 ## Wiki address
-# WIKIURL http://www.tgstation13.org/wiki
+# WIKIURL http://wiki.merchantstation.net/
 
 ## Rules address
-# RULESURL http://www.tgstation13.org/wiki/Rules
+# RULESURL http://wiki.merchantstation.net/wiki/Rules
 
 ## Github address
-# GITHUBURL https://www.github.com/tgstation/tgstation
+# GITHUBURL https://www.github.com/The-Merchants-Guild/Merchant-Station-13
 
 ## Discord bot command prefix, if the discord bot is used
 # DISCORDBOTCOMMANDPREFIX ?


### PR DESCRIPTION
## About The Pull Request

We still have /tg/'s links as default for Discord Invites, website and the wiki. This fixes that.

## Changelog
:cl:
config: Changed config URLs to use merchant station links
/:cl:
