### PR TITLE
Re-adds buckshot and slugs to the hacked autolathe.

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -856,12 +856,20 @@
 	build_path = /obj/item/ammo_casing/shotgun/rubbershot
 	category = list("hacked", "Security")
 
-/datum/design/shotgun_laser
-	name = "Laser Shell"
-	id = "laser_shell"
+/datum/design/shotgun_buck
+	name = "Buckshot Shell"
+	id = "shotgun_buck"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 3000, /datum/material/glass = 1000)
-	build_path = /obj/item/ammo_casing/shotgun/laser
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/buckshot
+	category = list("hacked", "Security")
+
+/datum/design/shotgun_slug
+	name = "Shotgun Slug"
+	id = "shotgun_slug"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/shotgun
 	category = list("hacked", "Security")
 
 /datum/design/shotgun_dart


### PR DESCRIPTION
That's right, this PR re-adds shotgun shells and slugs to the hacked autolathe. Shouldn't be a problem since they aren't as batshit insane as before.

Also, laser shells can now only be printed from seclathes.

## Changelog
:cl:
add: Shotgun shells and slugs can now be printed from hacked autolathes again.
/:cl:
