### PR TITLE
Makes the minimum required players for all deathmatch maps 2

### DIFF
--- a/code/modules/deathmatch/deathmatch_maps.dm
+++ b/code/modules/deathmatch/deathmatch_maps.dm
@@ -28,7 +28,7 @@
 /datum/deathmatch_map/maintenance
 	name = "Maint Mania"
 	desc = "Dark maintenance tunnels, floor pills, improvised weaponry and a bloody beatdown. Welcome to assistant utopia."
-	min_players = 4
+	min_players = 2
 	max_players = 8
 	allowed_loadouts = list(/datum/deathmatch_loadout/assistant)
 	map_path = "_maps/map_files/DM/Maint_Mania.dmm"
@@ -44,7 +44,7 @@
 /datum/deathmatch_map/the_brig
 	name = "The Brig"
 	desc = "A recreation of MetaStation Brig."
-	min_players = 4
+	min_players = 2
 	max_players = 12
 	allowed_loadouts = list(/datum/deathmatch_loadout/assistant)
 	map_path = "_maps/map_files/DM/The_Brig.dmm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
 All the deathmatch maps now require only two players to start.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The two maps currently locked to 4 players - Maint Mania and Brig, work perfectly fine with only two players fighting.
Maint Mania is based on the dark dingy tunnels of maintenance and rewards situational awareness, but also the map is compact enough to allow two players to easily find each other and brawl it out.
Brig is just the Metastation brig and I don't see how it exactly requires 4 players to fight.
Case in point, this server does not get much pop anyway and arbitrarily locking off two of the maps (one of which is just AMAZING) seems nonsensical.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: averagejoe22
tweak: All deathmatch maps now only require 2 players to start
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
