### PR TITLE
Makes operating computers work with stasis beds again

### DIFF
--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -3,12 +3,14 @@
 
 /obj/machinery/computer/operating
 	name = "operating computer"
-	desc = "Monitors patient vitals and displays surgery steps. Can be loaded with surgery disks to perform experimental procedures. Automatically syncs to operating tables within its line of sight for surgical tech advancement."
+	desc = "Monitors patient vitals and displays surgery steps. Can be loaded with surgery disks to perform experimental procedures. Automatically syncs to stasis beds within its line of sight for surgical tech advancement."
 	icon_screen = "crew"
 	icon_keyboard = "med_key"
 	circuit = /obj/item/circuitboard/computer/operating
 
+	var/mob/living/carbon/human/patient
 	var/obj/structure/table/optable/table
+	var/obj/machinery/stasis/sbed
 	var/list/advanced_surgeries = list()
 	var/datum/techweb/linked_techweb
 	light_color = LIGHT_COLOR_BLUE
@@ -23,6 +25,10 @@
 		table = locate(/obj/structure/table/optable) in get_step(src, direction)
 		if(table && table.computer == src)
 			table.computer = null
+		else
+			sbed = locate(/obj/machinery/stasis) in get_step(src, direction)
+			if(sbed && sbed.computer == src)
+				sbed.computer = null
 	. = ..()
 
 /obj/machinery/computer/operating/attackby(obj/item/O, mob/user, params)
@@ -49,6 +55,11 @@
 		if(table)
 			table.computer = src
 			break
+		else
+			sbed = locate(/obj/machinery/stasis) in get_step(src, direction)
+			if(sbed)
+				sbed.computer = src
+				break
 
 /obj/machinery/computer/operating/ui_state(mob/user)
 	return GLOB.not_incapacitated_state
@@ -69,17 +80,23 @@
 		surgery["desc"] = initial(S.desc)
 		surgeries += list(surgery)
 	data["surgeries"] = surgeries
-
-	//If there's no patient just hop to it yeah?
-	if(!table)
-		data["patient"] = null
-		return data
-
-	data["table"] = table
-	if(!table.check_eligible_patient())
-		return data
-	data["patient"] = list()
-	var/mob/living/carbon/human/patient = table.patient
+	data["patient"] = null
+	if(table)
+		data["table"] = table
+		if(!table.check_eligible_patient())
+			return data
+		data["patient"] = list()
+		patient = table.patient
+	else
+		if(sbed)
+			data["table"] = sbed
+			if(!ishuman(sbed.occupant))
+				return data
+			data["patient"] = list()
+			patient = sbed.occupant
+		else
+			data["patient"] = null
+			return data
 
 	switch(patient.stat)
 		if(CONSCIOUS)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -19,13 +19,17 @@
 	var/stasis_can_toggle = 0
 	var/mattress_state = "stasis_on"
 	var/obj/effect/overlay/vis/mattress_on
+	var/obj/machinery/computer/operating/computer
 
 /obj/machinery/stasis/Destroy()
 	. = ..()
+	if(computer && computer.sbed == src)
+		computer.sbed = null
 
 /obj/machinery/stasis/examine(mob/user)
 	. = ..()
 	. += span_notice("Alt-click to [stasis_enabled ? "turn off" : "turn on"] the machine.")
+	. += span_notice("\The [src] is [computer ? "linked" : "<b>NOT</b> linked"] to a nearby operating computer.")
 
 /obj/machinery/stasis/proc/play_power_sound()
 	var/_running = stasis_running()

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -78,6 +78,10 @@
 	var/obj/structure/table/optable/optable = locate(/obj/structure/table/optable, patient_turf)
 	if(optable?.computer)
 		opcomputer = optable.computer
+	else
+		var/obj/machinery/stasis/the_stasis_bed = locate(/obj/machinery/stasis, patient_turf)
+		if(the_stasis_bed?.computer)
+			opcomputer = the_stasis_bed.computer
 	if(!opcomputer)
 		return
 	if(opcomputer.machine_stat & (NOPOWER|BROKEN))


### PR DESCRIPTION
## About The Pull Request

Undoes tgstation/tgstation#57306 and part of tgstation/tgstation#59371

## Why It's Good For The Game

> Medical literally always moves the computers to the stasis beds, bypassing operating tables almost completely.

So? (There's only two of them roundstart on Meta anyways and we've got way more than 2 surgery tables/beds now)

> Stasis beds are not meant to be THE medical tool, yet they currently are.

They replaced sleepers, which WERE the medical tool. And who the fuck are you to judge? You're a sci player

> With this change, operating tables and stasis beds will each have their own niche

2 stasis beds is not enough of a fucking corpse queue to be a "niche"

> and it will hopefully provide a bit more diversity in how medical treat patients.

so you nerf the shit out of chems to make surgery viable, and then you nerf surgery so that... ????

## Changelog
:cl:
del: Operating computers can link to stasis beds again.
/:cl:
