### PR TITLE
Fixes issues caused by previous PRs

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -76,7 +76,7 @@
 		last_act = world.time
 		to_chat(user, span_notice("You start picking..."))
 
-		if(I.use_tool(src, user, 40, volume=50))
+		if(I.use_tool(src, user, 20, volume=50))
 			if(ismineralturf(src))
 				to_chat(user, span_notice("You finish cutting into the rock."))
 				gets_drilled(user, TRUE)

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -25,7 +25,6 @@
 
 	mail_goodies = list(
 		/obj/item/reagent_containers/glass/bottle/flash_powder = 15,
-		/obj/item/reagent_containers/glass/bottle/exotic_stabilizer = 5,
 		/obj/item/reagent_containers/glass/bottle/leadacetate = 5,
 		/obj/item/paper/secretrecipe = 1
 	)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -294,7 +294,7 @@
 		user.visible_message(span_notice("[user.name] starts to cut the [name] free from the floor."), \
 			span_notice("You start to cut [src] free from the floor..."), \
 			span_hear("You hear welding."))
-		if(!item.use_tool(src, user, 20, 1, 50))
+		if(!item.use_tool(src, user, amount=1, 50))
 			return FALSE
 		welded = FALSE
 		to_chat(user, span_notice("You cut [src] free from the floor."))
@@ -310,7 +310,7 @@
 	user.visible_message(span_notice("[user.name] starts to weld the [name] to the floor."), \
 		span_notice("You start to weld [src] to the floor..."), \
 		span_hear("You hear welding."))
-	if(!item.use_tool(src, user, 20, 1, 50))
+	if(!item.use_tool(src, user, amount=1, 50))
 		return FALSE
 	welded = TRUE
 	to_chat(user, span_notice("You weld [src] to the floor."))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2506,12 +2506,6 @@
 	taste_description = "hell"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/exotic_stabilizer
-	name = "Exotic Stabilizer"
-	description = "Advanced compound created by mixing stabilizing agent and hyper-plasmium oxide."
-	color = "#180000" // rgb: 255, 255, 255
-	taste_description = "blood"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/wittel
 	name = "Wittel"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -491,7 +491,7 @@
 
 /datum/chemical_reaction/carpet/simple_neon_purple
 	results = list(/datum/reagent/carpet/neon/simple_purple = 2)
-	required_reagents = list(/datum/reagent/carpet = 1, /datum/reagent/consumable/tinlux = 1, /datum/reagent/plasma_oxide = 1)
+	required_reagents = list(/datum/reagent/carpet = 1, /datum/reagent/consumable/tinlux = 1, /datum/reagent/stabilizing_agent = 1)
 
 /datum/chemical_reaction/carpet/simple_neon_violet
 	results = list(/datum/reagent/carpet/neon/simple_violet = 2)
@@ -741,10 +741,6 @@
 	required_catalysts = list(/datum/reagent/water/holywater = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_PLANT | REACTION_TAG_OTHER
 
-/datum/chemical_reaction/exotic_stabilizer
-	results = list(/datum/reagent/exotic_stabilizer = 2)
-	required_reagents = list(/datum/reagent/plasma_oxide = 1,/datum/reagent/stabilizing_agent = 1)
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL
 
 
 /datum/chemical_reaction/bone_gel

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -15,7 +15,7 @@
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 
-	if(holder.has_reagent(/datum/reagent/exotic_stabilizer,round(created_volume / 25, CHEMICAL_QUANTISATION_LEVEL)))
+	if(holder.has_reagent(/datum/reagent/stabilizing_agent,round(created_volume / 25, CHEMICAL_QUANTISATION_LEVEL)))
 		return
 	holder.remove_reagent(/datum/reagent/nitroglycerin, created_volume*2)
 	..()
@@ -81,7 +81,7 @@
 	required_temp = 450 + rand(-49,49)  //this gets loaded only on round start
 
 /datum/chemical_reaction/reagent_explosion/tatp/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	if(holder.has_reagent(/datum/reagent/exotic_stabilizer,round(created_volume / 50, CHEMICAL_QUANTISATION_LEVEL))) // we like exotic stabilizer
+	if(holder.has_reagent(/datum/reagent/stabilizing_agent,round(created_volume / 50, CHEMICAL_QUANTISATION_LEVEL))) // we like exotic stabilizer
 		return
 	holder.remove_reagent(/datum/reagent/tatp, created_volume)
 	..()

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -438,11 +438,6 @@
 	desc = "A small bottle. Contains flash powder."
 	list_reagents = list(/datum/reagent/flash_powder = 30)
 
-/obj/item/reagent_containers/glass/bottle/exotic_stabilizer
-	name = "exotic stabilizer bottle"
-	desc = "A small bottle. Contains exotic stabilizer."
-	list_reagents = list(/datum/reagent/exotic_stabilizer = 30)
-
 /obj/item/reagent_containers/glass/bottle/leadacetate
 	name = "lead acetate bottle"
 	desc = "A small bottle. Contains lead acetate."


### PR DESCRIPTION
guhuhh

## Changelog
:cl:
balance: Stabilizing TaTP and Nitroglycerin now uses normal stabilizing agent once more.
fix: Fixed welding emitters and mining delays.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
