### PR TITLE
Schizophrenia Medication (Adds heart, lung and liver healing chems that work in cadavers)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -712,6 +712,57 @@
 	. = ..()
 	UnregisterSignal(owner, COMSIG_MOVABLE_HEAR)
 
+/datum/reagent/medicine/capoten
+	name = "Capoten"
+	description = "Restores heart damage. Most effective in corpses."
+	reagent_state = LIQUID
+	color = "#801818" //dark red-ish
+	purity = REAGENT_STANDARD_PURITY
+	impure_chem = null
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
+/datum/reagent/medicine/capoten/on_mob_life(mob/living/carbon/C, delta_time, times_fired)
+	C.adjustOrganLoss(ORGAN_SLOT_HEART, -0.3 * REM * delta_time * normalise_creation_purity())
+	..()
+
+/datum/reagent/medicine/capoten/on_mob_dead(mob/living/carbon/C, delta_time)
+	C.adjustOrganLoss(ORGAN_SLOT_HEART, -1.8 * REM * delta_time * normalise_creation_purity())
+	..()
+
+/datum/reagent/medicine/albuterol
+	name = "Albuterol"
+	description = "Restores lung damage. Works best in corpses."
+	reagent_state = LIQUID
+	color = "#123b61"
+	purity = REAGENT_STANDARD_PURITY
+	impure_chem = null
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
+/datum/reagent/medicine/albuterol/on_mob_life(mob/living/carbon/C, delta_time, times_fired)
+	C.adjustOrganLoss(ORGAN_SLOT_LUNGS, -0.3 * REM * delta_time * normalise_creation_purity())
+	..()
+
+/datum/reagent/medicine/albuterol/on_mob_dead(mob/living/carbon/C, delta_time)
+	C.adjustOrganLoss(ORGAN_SLOT_LUNGS, -1.8 * REM * delta_time * normalise_creation_purity())
+	..()
+
+/datum/reagent/medicine/ursodeoxycholicacid
+	name = "Ursodeoxycholic acid"
+	description = "Restores liver damage. Works best in corpses."
+	reagent_state = LIQUID
+	color = "#3d2b2b"
+	purity = REAGENT_STANDARD_PURITY
+	impure_chem = null
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
+/datum/reagent/medicine/ursodeoxycholicacid/on_mob_life(mob/living/carbon/C, delta_time, times_fired)
+	C.adjustOrganLoss(ORGAN_SLOT_LIVER, -0.3 * REM * delta_time * normalise_creation_purity())
+	..()
+
+/datum/reagent/medicine/ursodeoxycholicacid/on_mob_dead(mob/living/carbon/C, delta_time)
+	C.adjustOrganLoss(ORGAN_SLOT_LIVER, -1.8 * REM * delta_time * normalise_creation_purity())
+	..()
+
 /datum/reagent/medicine/atropine
 	name = "Atropine"
 	description = "If a patient is in critical condition, rapidly heals all damage types as well as regulating oxygen in the body. Excellent for stabilizing wounded patients."

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -73,6 +73,22 @@
 	holder.my_atom.audible_message(span_notice("[icon2html(holder.my_atom, viewers(DEFAULT_MESSAGE_RANGE, src))]The [holder.my_atom] suddenly gives out a loud bang!"))
 	explode_deafen(holder, equilibrium, 0.5, 10, 3)
 
+/datum/chemical_reaction/medicine/capoten
+	results = list(/datum/reagent/medicine/capoten = 3)
+	required_reagents = list(/datum/reagent/medicine/c2/multiver = 1, /datum/reagent/oxygen = 1, /datum/reagent/consumable/sugar = 1)
+	mix_message = "The mixture starts beating with a steady rhythm as it becomes a dark red color!"
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_ORGAN
+
+/datum/chemical_reaction/medicine/albuterol
+	results = list(/datum/reagent/medicine/albuterol = 3)
+	required_reagents = list(/datum/reagent/medicine/c2/multiver = 1, /datum/reagent/nitrogen = 1, /datum/reagent/potassium = 1)
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_ORGAN
+
+/datum/chemical_reaction/medicine/ursodeoxycholicacid
+	results = list(/datum/reagent/medicine/ursodeoxycholicacid = 3)
+	required_reagents = list(/datum/reagent/medicine/c2/multiver = 1, /datum/reagent/copper = 1, /datum/reagent/silicon = 1)
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_ORGAN
+
 /datum/chemical_reaction/medicine/synaptizine
 	results = list(/datum/reagent/medicine/synaptizine = 3)
 	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1, /datum/reagent/water = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds three new medicines for healing organ damage.
Multiver + Oxygen + Sugar -> (3) Capoten
Multiver + Nitrogen + Potassium -> (3) Albuterol
Multiver + Copper + Silicon -> (3) Ursodeoxycholic acid

All three decay at the base 0.4u/tick.

All three heal 0.3 damage / tick in a live person and 1.8 in a cadaver, being six times as efficient when administered to corpses.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Chem boys have ways to heal dead organs of dead people for revival.

## Changelog
:cl:
add: Three new chemicals: Capoten, Albuterol and Ursodeoxycholic acid, used to treat heart, lung and liver damage respectively. Work best in cadavers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
