### PR TITLE
Makes the singulo work for power generation again

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -133,6 +133,7 @@
 
 /obj/singularity/process(delta_time)
 	if(current_size >= STAGE_TWO)
+		radiation_pulse(src, min(5000, (energy * 4.5) + 1000), RAD_DISTANCE_COEFFICIENT * 0.5)
 		if(prob(event_chance))//Chance for it to run a special event TODO:Come up with one or two more that fit
 			event()
 	dissipate(delta_time)


### PR DESCRIPTION
## About The Pull Request

Makes the singularity actually emit radiation again; was removed in the same PR that removed the singulo and tesla for power generation (tgstation/tgstation#52873).

## Why It's Good For The Game

ALL HAIL LORD SINGULOTH
![HE COMES](https://user-images.githubusercontent.com/34369281/169635972-aab29a3b-be8f-4d39-adc9-7fd84c3d70e1.png)

## Changelog
:cl:
balance: The singulo can now be used for power generation again
/:cl:
