### PR TITLE
Fixes automatic viewport fitting

### DIFF
--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -4,6 +4,7 @@
 	var/width = 0
 	var/height = 0
 	var/default = ""
+	var/zoom = 0
 	var/is_suppressed = FALSE
 	var/client/chief = null
 
@@ -11,6 +12,10 @@
 	default = view_string
 	chief = owner
 	apply()
+
+/datum/view_data/Destroy()
+	chief = null
+	return ..()
 
 /datum/view_data/proc/setDefault(string)
 	default = string
@@ -24,12 +29,15 @@
 
 /datum/view_data/proc/assertFormat()//T-Pose
 	winset(chief, "mapwindow.map", "zoom=0")
+	zoom = 0
 
 /datum/view_data/proc/resetFormat()//Cuck
-	winset(chief, "mapwindow.map", "zoom=[chief.prefs.pixel_size]")
+	zoom = chief?.prefs.pixel_size
+	winset(chief, "mapwindow.map", "zoom=[zoom]")
+	chief?.attempt_auto_fit_viewport() // If you change zoom mode, fit the viewport
 
 /datum/view_data/proc/setZoomMode()
-	winset(chief, "mapwindow.map", "zoom-mode=[chief.prefs.scaling_method]")
+	winset(chief, "mapwindow.map", "zoom-mode=[chief?.prefs.scaling_method]")
 
 /datum/view_data/proc/isZooming()
 	return (width || height)
@@ -78,7 +86,7 @@
 	apply()
 
 /datum/view_data/proc/apply()
-	chief.change_view(getView())
+	chief?.change_view(getView())
 	safeApplyFormat()
 
 /datum/view_data/proc/supress()

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -213,3 +213,6 @@
 	var/interviewee = FALSE
 
 	var/country
+
+	/// If this client has been fully initialized or not
+	var/fully_created = FALSE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -447,6 +447,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	view_size.setZoomMode()
 	Master.UpdateTickRate()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CLIENT_CONNECT, src)
+	fully_created = TRUE
 
 //////////////
 //DISCONNECT//
@@ -988,8 +989,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if (isliving(mob))
 		var/mob/living/M = mob
 		M.update_damage_hud()
-	if (prefs.auto_fit_viewport)
-		addtimer(CALLBACK(src,.verb/fit_viewport,10)) //Delayed to avoid wingets from Login calls.
+	attempt_auto_fit_viewport()
 
 /client/proc/generate_clickcatcher()
 	if(!void)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -372,13 +372,23 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 	var/list/map_size = splittext(sizes["mapwindow.size"], "x")
 
-	// Looks like we expect mapwindow.size to be "ixj" where i and j are numbers.
-	// If we don't get our expected 2 outputs, let's give some useful error info.
-	if(length(map_size) != 2)
-		CRASH("map_size of incorrect length --- map_size var: [map_size] --- map_size length: [length(map_size)]")
+	// Gets the type of zoom we're currently using from our view datum
+	// If it's 0 we do our pixel calculations based off the size of the mapwindow
+	// If it's not, we already know how big we want our window to be, since zoom is the exact pixel ratio of the map
+	var/zoom_value = src.view_size?.zoom || 0
 
-	var/height = text2num(map_size[2])
-	var/desired_width = round(height * aspect_ratio)
+	var/desired_width = 0
+	if(zoom_value)
+		desired_width = round(view_size[1] * zoom_value * world.icon_size)
+	else
+
+		// Looks like we expect mapwindow.size to be "ixj" where i and j are numbers.
+		// If we don't get our expected 2 outputs, let's give some useful error info.
+		if(length(map_size) != 2)
+			CRASH("map_size of incorrect length --- map_size var: [map_size] --- map_size length: [length(map_size)]")
+		var/height = text2num(map_size[2])
+		desired_width = round(height * aspect_ratio)
+
 	if (text2num(map_size[1]) == desired_width)
 		// Nothing to do
 		return
@@ -414,6 +424,14 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		pct += delta
 		winset(src, "mainwindow.split", "splitter=[pct]")
 
+/// Attempt to automatically fit the viewport, assuming the user wants it
+/client/proc/attempt_auto_fit_viewport()
+	if (!prefs.auto_fit_viewport)
+		return
+	if(fully_created)
+		INVOKE_ASYNC(src, .verb/fit_viewport)
+	else //Delayed to avoid wingets from Login calls.
+		addtimer(CALLBACK(src, .verb/fit_viewport, 1 SECONDS))
 
 /client/verb/policy()
 	set name = "Show Policy"


### PR DESCRIPTION
## About The Pull Request

Ports tgstation/tgstation#65225, kitbashes it a bit. Also worth noting that this fixes the width of the viewport when using pixel perfect scaling (like I do).

Before fix (Pixel Perfect 2x, Nearest Neighbor):
![before-fix](https://user-images.githubusercontent.com/34369281/169690974-da022e07-ef17-41d6-8754-dee74d7e3199.png)

After fix:
![after-fix](https://user-images.githubusercontent.com/34369281/169690976-b76706f1-8869-426a-9382-39942d8b3393.png)

Notice how the fitted viewport no longer has horizontal letterboxing (the vertical letterboxing, unfortunately, is inherent to using 2x pixel perfect scaling at 1080p. such is life)

## Why It's Good For The Game

I don't have to pixel hunt after horizontal letterboxing of the viewport now (JK I never did because I'm lazy)

## Changelog
:cl:
fix: Fixes automatic viewport fitting
/:cl: