### PR TITLE
Add ability to stash normal-sized items in potted plants.

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -29,6 +29,7 @@
 	var/rustle_sound = TRUE //play rustle sound on interact.
 	var/allow_quick_empty = FALSE //allow empty verb which allows dumping on the floor of everything inside quickly.
 	var/allow_quick_gather = FALSE //allow toggle mob verb which toggles collecting all items from a tile.
+	var/insert_while_closed = TRUE //user can insert items into storage by clicking on it without opening its inventory, else inventory has to be opened first
 
 	var/collection_mode = COLLECT_EVERYTHING
 
@@ -632,6 +633,8 @@
 		if(M && !stop_messages)
 			host.add_fingerprint(M)
 			to_chat(M, span_warning("[host] seems to be locked!"))
+		return FALSE
+	if(!insert_while_closed && !(M in is_using))
 		return FALSE
 	if(real_location.contents.len >= max_items)
 		if(!stop_messages)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -317,10 +317,17 @@
 	var/trimmable = TRUE
 	var/list/static/random_plant_states
 
+/// Storage type for plants
+/datum/component/storage/concrete/kirbyplants
+	max_w_class = WEIGHT_CLASS_NORMAL
+	max_items = 1
+	insert_while_closed = FALSE
+
 /obj/item/kirbyplants/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/tactical)
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE, force_unwielded=10, force_wielded=10)
+	AddComponent(/datum/component/storage/concrete/kirbyplants)
 	AddElement(/datum/element/beauty, 500)
 
 /obj/item/kirbyplants/attackby(obj/item/I, mob/living/user, params)


### PR DESCRIPTION
## About The Pull Request
Adds ability to stash normal-sized items in potted plants.
Made small change to /datum/component/storage.  Adds an option to disable item inserting if storage inventory is not open.
Was required for potted plant stashing to avoid accidental item stashing. This option is set to false by default.

## Why It's Good For The Game
More creative ways of hiding items.

## Changelog
:cl:
add: Add ability to stash normal-sized items in potted plants.
code: Added new variable insert_while_closed to /datum/component/storage.
/:cl: