### PR TITLE
Fix Wikibooks

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -220,13 +220,13 @@
 /datum/config_entry/string/banappeals
 
 /datum/config_entry/string/wikiurl
-	default = "http://wiki.merchantstation.net/w"
+	default = "https://wiki.merchantstation.net/wiki"
 
 /datum/config_entry/string/discordurl
 	default = "https://discord.gg/2YYfU3ZanD"
 
 /datum/config_entry/string/rulesurl
-	default = "http://wiki.merchantstation.net/wiki/Rules"
+	default = "https://wiki.merchantstation.net/wiki/Rules"
 
 /datum/config_entry/string/githuburl
 	default = "https://www.github.com/The-Merchants-Guild/Merchant-Station-13"

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -267,7 +267,7 @@
 			}
 			</script>
 			<p id='loading'>You start skimming through the manual...</p>
-			<iframe width='100%' height='97%' onload="pageloaded(this)" src="[wikiurl]/[page_link]?printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
+			<iframe width='100%' height='97%' onload="pageloaded(this)" src="[wikiurl]/[page_link]?printable=yes" frameborder="0" id="main_frame"></iframe>
 			</body>
 
 			</html>

--- a/config/config.txt
+++ b/config/config.txt
@@ -247,7 +247,7 @@ WEBCLIENT_ONLY_BYOND_MEMBERS
 # FORUMURL http://tgstation13.org/phpBB/index.php
 
 ## Wiki address
-# WIKIURL http://wiki.merchantstation.net/
+WIKIURL https://wiki.merchantstation.net/wiki
 
 ## Rules address
 # RULESURL http://wiki.merchantstation.net/wiki/Rules

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -6,7 +6,7 @@
 	var/wikiurl = CONFIG_GET(string/wikiurl)
 	if(wikiurl)
 		if(query)
-			var/output = wikiurl + "/index.php?title=Special%3ASearch&profile=default&search=" + query
+			var/output = wikiurl + "/Special%3ASearch?search=" + query
 			src << link(output)
 		else if (query != null)
 			src << link(wikiurl)


### PR DESCRIPTION
## About The Pull Request

Fixes wikibooks. This isn't totally our fault; /tg/station's wiki installation is the improperly done one.

## Changelog
:cl:
fix: Fixes wikibooks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
