### PR TITLE
SLIPS HARDSTUN AGAIN

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -171,7 +171,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 /datum/material/bananium/on_applied(atom/source, amount, material_flags)
 	. = ..()
 	source.LoadComponent(/datum/component/squeak, list('sound/items/bikehorn.ogg'=1), 50, falloff_exponent = 20)
-	source.AddComponent(/datum/component/slippery, min(amount / 10, 80))
+	source.AddComponent(/datum/component/slippery, min(amount / 10, 80), paralyze=min(amount / 10, 80))
 
 /datum/material/bananium/on_removed(atom/source, amount, material_flags)
 	. = ..()

--- a/code/game/objects/effects/decals/cleanable/robots.dm
+++ b/code/game/objects/effects/decals/cleanable/robots.dm
@@ -98,4 +98,4 @@
 
 /obj/effect/decal/cleanable/oil/slippery/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 80, (NO_SLIP_WHEN_WALKING | SLIDE))
+	AddComponent(/datum/component/slippery, 80, (NO_SLIP_WHEN_WALKING | SLIDE), paralyze=50)

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -99,7 +99,7 @@
 /obj/effect/particle_effect/foam/ComponentInitialize()
 	. = ..()
 	if(slippery_foam)
-		AddComponent(/datum/component/slippery, 100)
+		AddComponent(/datum/component/slippery, 100, paralyze=100)
 
 /obj/effect/particle_effect/foam/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -30,7 +30,7 @@
 
 /obj/item/soap/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 80)
+	AddComponent(/datum/component/slippery, 50, paralyze=50)
 
 /obj/item/soap/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -11,7 +11,7 @@
 
 /obj/item/pda/clown/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery/clowning, 120, NO_SLIP_WHEN_WALKING, CALLBACK(src, .proc/AfterSlip), slot_whitelist = list(ITEM_SLOT_ID, ITEM_SLOT_BELT))
+	AddComponent(/datum/component/slippery/clowning, 120, NO_SLIP_WHEN_WALKING, CALLBACK(src, .proc/AfterSlip), paralyze=120, slot_whitelist = list(ITEM_SLOT_ID, ITEM_SLOT_BELT))
 	AddComponent(/datum/component/wearertargeting/sitcomlaughter, CALLBACK(src, .proc/after_sitcom_laugh))
 
 /obj/item/pda/clown/proc/AfterSlip(mob/living/carbon/human/M)

--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -336,4 +336,4 @@
 
 /obj/item/food/butterdog/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 80)
+	AddComponent(/datum/component/slippery, 80, paralyze=80)

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -524,7 +524,7 @@
 
 /obj/item/food/meatclown/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 30)
+	AddComponent(/datum/component/slippery, 30, paralyze=30)
 
 /obj/item/food/lasagna
 	name = "Lasagna"

--- a/code/modules/antagonists/clown_ops/clown_weapons.dm
+++ b/code/modules/antagonists/clown_ops/clown_weapons.dm
@@ -84,7 +84,7 @@
  */
 /obj/item/melee/transforming/energy/sword/proc/adjust_slipperiness()
 	if(active)
-		AddComponent(/datum/component/slippery, 60, GALOSHES_DONT_HELP)
+		AddComponent(/datum/component/slippery, 60, GALOSHES_DONT_HELP, paralyze=60)
 	else
 		qdel(GetComponent(/datum/component/slippery))
 
@@ -147,7 +147,7 @@
  */
 /obj/item/shield/energy/bananium/proc/adjust_slipperiness()
 	if(active)
-		AddComponent(/datum/component/slippery, 60, GALOSHES_DONT_HELP)
+		AddComponent(/datum/component/slippery, 60, GALOSHES_DONT_HELP, paralyze=60)
 	else
 		qdel(GetComponent(/datum/component/slippery))
 
@@ -205,7 +205,7 @@
 
 /obj/item/grown/bananapeel/bombanana/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, det_time)
+	AddComponent(/datum/component/slippery, det_time, paralyze=det_time)
 
 /obj/item/grown/bananapeel/bombanana/Destroy()
 	. = ..()

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -143,4 +143,4 @@
 
 /obj/item/grown/bananapeel/specialpeel/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 40)
+	AddComponent(/datum/component/slippery, 40, paralyze=40)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -360,7 +360,7 @@
 	if(!istype(our_plant, /obj/item/grown/bananapeel) && (!our_plant.reagents || !our_plant.reagents.has_reagent(/datum/reagent/lube)))
 		stun_len /= 3
 
-	our_plant.AddComponent(/datum/component/slippery, min(stun_len, 140), NONE, CALLBACK(src, .proc/handle_slip, our_plant))
+	our_plant.AddComponent(/datum/component/slippery, min(stun_len, 140), NONE, CALLBACK(src, .proc/handle_slip, our_plant), paralyze=min(stun_len, 140))
 
 /// On slip, sends a signal that our plant was slipped on out.
 /datum/plant_gene/trait/slip/proc/handle_slip(obj/item/food/grown/our_plant, mob/slipped_target)


### PR DESCRIPTION
TG MAKING SLIPS NO LONGER ACTUALLY STUN HAS GOT TO HAVE BEEN THE DUMBEST DECISION THEY HAVE EVER MADE, THEREFORE, I AM BRINGING BACK THE GOOD OLD DAYS.
## Changelog
:cl:
balance: Slips stun you again. God's in his Heaven, all is right with the world.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
