### PR TITLE
Fixes escaping the DM(I hope)

### DIFF
--- a/_maps/map_files/DM/Maint_Mania.dmm
+++ b/_maps/map_files/DM/Maint_Mania.dmm
@@ -3,10 +3,8 @@
 /turf/closed/indestructible/reinforced,
 /area/deathmatch)
 "aP" = (
-/obj/machinery/door/airlock/centcom{
-	req_access_txt = "201"
-	},
-/turf/open/space/basic,
+/obj/structure/sign/poster/official/no_erp,
+/turf/closed/indestructible/reinforced,
 /area/deathmatch)
 "bI" = (
 /obj/machinery/light/no_nightlight/directional/north,
@@ -177,6 +175,9 @@
 /obj/item/stack/cable_coil,
 /obj/item/assembly/igniter,
 /turf/open/indestructible,
+/area/deathmatch)
+"uD" = (
+/turf/open/floor/plating,
 /area/deathmatch)
 "vB" = (
 /obj/machinery/light/small/directional/east,
@@ -462,21 +463,16 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/indestructible,
 /area/deathmatch)
 "Vb" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/indestructible,
 /area/deathmatch)
 "Xb" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/indestructible,
+/turf/closed/indestructible/fakeglass,
 /area/deathmatch)
 "XC" = (
 /obj/item/assembly/igniter,
@@ -624,13 +620,13 @@ aD
 aD
 aD
 aD
-ho
-ho
-ho
-ho
-ho
-ho
-ho
+Xb
+Xb
+Xb
+Xb
+Xb
+Xb
+Xb
 aD
 aD
 aD
@@ -823,7 +819,7 @@ ho
 aD
 aD
 Vb
-hB
+aP
 ga
 Dh
 Ij
@@ -853,7 +849,7 @@ cn
 cn
 Rm
 aD
-Xb
+cn
 aD
 Ij
 Ij
@@ -892,7 +888,7 @@ Ij
 Ij
 "}
 (14,1,1) = {"
-aP
+aD
 cn
 cn
 cn
@@ -1016,7 +1012,7 @@ ga
 ga
 "}
 (18,1,1) = {"
-aP
+aD
 cn
 cn
 cn
@@ -1102,7 +1098,7 @@ ga
 Ij
 ho
 cn
-ho
+Xb
 Ij
 Ij
 ga
@@ -1133,7 +1129,7 @@ ga
 ga
 ho
 nQ
-ho
+Xb
 Ij
 Ij
 ga
@@ -1271,7 +1267,7 @@ Ij
 Ij
 ga
 Ij
-ho
+Xb
 cn
 cn
 pZ
@@ -1302,7 +1298,7 @@ Ij
 Ij
 ga
 Ij
-ho
+Xb
 pT
 sF
 Mt
@@ -1345,7 +1341,7 @@ cn
 cn
 cn
 cn
-ho
+Xb
 Ij
 Ij
 Ij
@@ -1374,7 +1370,7 @@ Hp
 cn
 aD
 aD
-ho
+uD
 aD
 aD
 Ij
@@ -1402,8 +1398,8 @@ zd
 nQ
 aD
 EN
-cn
-ho
+Xb
+Xb
 Ij
 Ij
 Ij
@@ -1461,9 +1457,9 @@ Ij
 Ij
 aD
 aD
-ho
-ho
-ho
+Xb
+Xb
+Xb
 aD
 aD
 ga

--- a/_maps/map_files/DM/OSHA_Violator.dmm
+++ b/_maps/map_files/DM/OSHA_Violator.dmm
@@ -907,12 +907,7 @@
 /obj/machinery/disposal/delivery_chute,
 /turf/open/indestructible,
 /area/deathmatch)
-"NY" = (
-/obj/machinery/the_singularitygen,
-/turf/open/indestructible,
-/area/deathmatch)
 "Pg" = (
-/obj/machinery/field/generator/anchored,
 /obj/machinery/light/no_nightlight/directional/north,
 /turf/open/indestructible,
 /area/deathmatch)
@@ -1291,7 +1286,7 @@ zl
 cA
 HL
 ai
-NY
+cA
 Rk
 ai
 ai


### PR DESCRIPTION
why didn't you make them indestructible windows from the start REEEEEEEEEE

## Changelog
:cl:
fix: Can't get to CC from the deathmatch map. Also removed the singularity/tesla from OSHA violator for obvious reasons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
