### PR TITLE
Revert "Makes Null_crates cheaper by a factor of three"

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -185,7 +185,7 @@
 	name = "NULL_ENTRY"
 	desc = "(#@&^$THIS PACKAGE CONTAINS 30TC WORTH OF SOME RANDOM SYNDICATE GEAR WE HAD LYING AROUND THE WAREHOUSE. GIVE EM HELL, OPERATIVE@&!*() "
 	hidden = TRUE
-	cost = CARGO_CRATE_VALUE * 30
+	cost = CARGO_CRATE_VALUE * 100
 	contains = list()
 	crate_name = "emergency crate"
 	crate_type = /obj/structure/closet/crate/internals


### PR DESCRIPTION
Reverts The-Merchants-Guild/Merchant-Station-13#200

God damn. It was obvious that this was gonna make surplus crates more common, but virtually every round a cargo or QM has tator, they just emag the console and buy money briefcases and get more shit than a warops nukie.

![haram-astaghfirullah](https://user-images.githubusercontent.com/34369281/172032107-fa87fc59-4391-40ca-b2be-8be8cb5e5aac.gif)

## Changelog
🆑
balance: Due to the sudden uptick in demand, the price on surplus crates has been reinflated.
/🆑