### PR TITLE
A few small chem fixes

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -219,8 +219,9 @@
 
 	for(var/obj/item/slime_extract/S in beakers)
 		if(S.Uses)
-			for(var/obj/item/reagent_containers/glass/G in beakers)
-				G.reagents.trans_to(S, G.reagents.total_volume)
+			for(var/obj/item/reagent_containers/B in beakers)
+				if(!istype(B, /obj/item/slime_extract))
+					B.reagents.trans_to(S, B.reagents.total_volume)
 
 			//If there is still a core (sometimes it's used up)
 			//and there are reagents left, behave normally,
@@ -228,8 +229,9 @@
 
 			if(S)
 				if(S.reagents && S.reagents.total_volume)
-					for(var/obj/item/reagent_containers/glass/G in beakers)
-						S.reagents.trans_to(G, S.reagents.total_volume)
+					for(var/obj/item/reagent_containers/B in beakers)
+						if(!istype(B, /obj/item/slime_extract))
+							S.reagents.trans_to(B, S.reagents.total_volume)
 				else
 					S.forceMove(get_turf(src))
 					no_splash = TRUE

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -32,9 +32,9 @@
 	if(user.can_see_reagents())
 		if(beakers.len)
 			. += span_notice("You scan the grenade and detect the following reagents:")
-			for(var/obj/item/reagent_containers/glass/G in beakers)
-				for(var/datum/reagent/R in G.reagents.reagent_list)
-					. += span_notice("[R.volume] units of [R.name] in the [G.name].")
+			for(var/obj/item/reagent_containers/B in beakers)
+				for(var/datum/reagent/R in B.reagents.reagent_list)
+					. += span_notice("[R.volume] units of [R.name] in the [B.name].")
 			if(beakers.len == 1)
 				. += span_notice("You detect no second beaker in the grenade.")
 		else

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -6,8 +6,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	force = 2
 	var/stage = GRENADE_EMPTY
-	var/list/obj/item/reagent_containers/glass/beakers = list()
-	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle)
+	var/list/obj/item/reagent_containers/beakers = list()
+	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/food/drinks/waterbottle)
 	var/list/banned_containers = list(/obj/item/reagent_containers/glass/beaker/bluespace) //Containers to exclude from specific grenade subtypes
 	var/affected_area = 3
 	var/ignition_temp = 10 // The amount of heat added to the reagents when this grenade goes off.
@@ -180,8 +180,8 @@
 
 	. = ..()
 	var/list/datum/reagents/reactants = list()
-	for(var/obj/item/reagent_containers/glass/G in beakers)
-		reactants += G.reagents
+	for(var/obj/item/reagent_containers/B in beakers)
+		reactants += B.reagents
 
 	var/turf/detonation_turf = get_turf(src)
 

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -250,6 +250,9 @@
 	var/power = modifier + round(created_volume/strengthdiv, 1)
 	if(power > 0)
 		var/turf/T = get_turf(holder.my_atom)
+		if(isorgan(holder.my_atom) && !T) // bandaid fix since get_turf doesn't work on organs in the body
+			var/obj/item/organ/curorgan = holder.my_atom
+			T = get_turf(curorgan.owner)
 		var/inside_msg
 		if(ismob(holder.my_atom))
 			var/mob/M = holder.my_atom


### PR DESCRIPTION
## About The Pull Request

Fixes a few minor minor bugs regarding chemnades as well as chemical explosions inside a player's stomach. Also allows plastic bottles to be used in chemnades (as well as fixing non-beaker reagent containers working in large nades). Shout out to @NonCoderAlias for pointing these out.

## Why It's Good For The Game

Being able to build ghetto nades out of plastic sheets and metal should be more accessible to other players. While assistants should never be able to get items as powerful as endgame departments, they should still be able to have a fair bit of freedom with what arms they can amass.

## Changelog
:cl:
balance: Plastic bottles can now be used in chemical grenades.
fix: Alternate reagent containers now work in large grenades again.
fix: Chemical explosions now work in the stomach again (this was not a rebalance, it generated runtime errors)
/:cl:
