### PR TITLE
Heretic Buffs

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -24,10 +24,8 @@
 				to_chat(user,span_warning("[target.real_name] is near you. They are to the [dir2text(dir)] of you!"))
 			if(16 to 31)
 				to_chat(user,span_warning("[target.real_name] is somewhere in your vicinity. They are to the [dir2text(dir)] of you!"))
-			if(32 to 127)
-				to_chat(user,span_warning("[target.real_name] is far away from you. They are to the [dir2text(dir)] of you!"))
 			else
-				to_chat(user,span_warning("[target.real_name] is beyond our reach."))
+				to_chat(user,span_warning("[target.real_name] is far away from you. They are to the [dir2text(dir)] of you!"))
 
 	if(target.stat == DEAD)
 		to_chat(user,span_warning("[target.real_name] is dead. Bring them to a transmutation rune!"))

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -69,8 +69,7 @@
 		use_charge = TRUE
 		var/mob/living/carbon/C = target
 		C.adjustBruteLoss(10)
-		C.AdjustKnockdown(5 SECONDS)
-		C.adjustStaminaLoss(80)
+		C.Paralyze(3 SECONDS)
 	var/list/knowledge = cultie.get_all_knowledge()
 
 	for(var/X in knowledge)

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -70,6 +70,7 @@
 		var/mob/living/carbon/C = target
 		C.adjustBruteLoss(10)
 		C.Paralyze(3 SECONDS)
+		C.stuttering += 8
 	var/list/knowledge = cultie.get_all_knowledge()
 
 	for(var/X in knowledge)

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -121,10 +121,11 @@
 	route = PATH_RUST
 
 /datum/eldritch_knowledge/rust_blade_upgrade/on_eldritch_blade(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
-	if(iscarbon(target))
-		var/mob/living/carbon/carbon_target = target
-		carbon_target.reagents.add_reagent(/datum/reagent/eldritch, 5)
+	. = ..()	
+	var/mob/living/carbon/carbon_user = user
+	var/mob/living/carbon/carbon_target = target
+	if(istype(carbon_user) && istype(carbon_target))
+		carbon_target.adjustToxLoss((carbon_user.maxHealth - carbon_user.health)/10)
 
 /datum/eldritch_knowledge/spell/entropic_plume
 	name = "Entropic Plume"

--- a/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
@@ -38,7 +38,7 @@
 	var/turf/open/turfie = get_turf(carbon_target)
 	turfie.TakeTemperature(-20)
 	carbon_target.adjust_bodytemperature(-40)
-	carbon_target.silent += 4
+	carbon_target.silent += 6
 	return TRUE
 
 /datum/eldritch_knowledge/void_grasp/on_eldritch_blade(atom/target, mob/user, proximity_flag, click_parameters)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The following changes to heretics:
1. Living heart no longer has a range limit; as long as your target is on the same zlevel, you can track it.
2. Mansus fist now always paralyzes and causes stuttering
3. Rust blade now deals toxic damage the lower the heretic's health is

## Why It's Good For The Game

Really feels like Heretics could be a great antag, but was cuck-coded in the beginning on tg, because tgmins don't like being robusted while trying to ERP. 

Good luck trying to score your 10 kills while your only spell does a measly knockdown and your target can just shout "xxx heretic" which makes you valid for the entire station, unless you're the super duper OP void heretic.

So yea, that's the 3 second stun on mansus, living heart range, and feels like the rust blade was the most boring blade of them all and doesn't play off of the rust heretic's high regen.

## Changelog
:cl:
balance: Living heart no longer has a range limit; as long as your target is on the same zlevel, you can track it.
balance: Mansus fist now always paralyzes and causes stuttering
add: Rust blade now deals toxic damage the lower the heretic's health is
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
