### PR TITLE
wiremod proximity pinpointer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,5 @@ Temporary Items
 /tools/LinuxOneShot/TGS_Logs
 config/config.txt
 tgstation.dme
+config/admins.txt
+config/config.txt

--- a/.gitignore
+++ b/.gitignore
@@ -195,5 +195,3 @@ Temporary Items
 /tools/LinuxOneShot/TGS_Logs
 config/config.txt
 tgstation.dme
-config/admins.txt
-config/config.txt

--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -163,6 +163,11 @@
 	id = "comp_direction"
 	build_path = /obj/item/circuit_component/direction
 
+/datum/design/component/pinpointer
+	name = "Pinpointer Component"
+	id = "comp_pinpointer"
+	build_path = /obj/item/circuit_component/pinpointer
+
 /datum/design/component/health
 	name = "Health Component"
 	id = "comp_health"
@@ -230,7 +235,7 @@
 	name = "To Entity Component"
 	id = "comp_toentity"
 	build_path = /obj/item/circuit_component/toentity
-	
+
 /datum/design/component/select_query
 	name = "Select Query Component"
 	id = "comp_select_query"
@@ -256,7 +261,7 @@
 	id = "comp_module"
 	build_path = /obj/item/circuit_component/module
 	build_type = IMPRINTER | COMPONENT_PRINTER
-	
+
 /datum/design/component/bci
 	category = list("Circuitry", "BCI Components")
 	build_type = IMPRINTER | COMPONENT_PRINTER

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -208,6 +208,7 @@
 		"comp_concat_list",
 		"comp_delay",
 		"comp_direction",
+		"comp_pinpointer",
 		"comp_get_column",
 		"comp_gps",
 		"comp_health",

--- a/code/modules/wiremod/components/atom/pinpointer.dm
+++ b/code/modules/wiremod/components/atom/pinpointer.dm
@@ -12,13 +12,19 @@
 	var/datum/port/output/x_pos
 	var/datum/port/output/y_pos
 	var/datum/port/output/z_pos
+
 	var/datum/port/output/on_error
 
 	var/max_range = 7
 
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
+/obj/item/circuit_component/pinpointer/get_ui_notices()
+	. = ..()
+	. += create_ui_notice("Maximum Range: [max_range] tiles", "orange", "info")
+
 /obj/item/circuit_component/pinpointer/Initialize()
+	. = ..()
 	target = add_input_port("Target entity", PORT_TYPE_ATOM, FALSE)
 
 	x_pos = add_output_port("X", PORT_TYPE_NUMBER)
@@ -26,32 +32,24 @@
 	z_pos = add_output_port("Z", PORT_TYPE_NUMBER)
 	on_error = add_output_port("Failed", PORT_TYPE_SIGNAL)
 
-/obj/item/circuit_component/direction/Destroy()
-	input_port = null
-	output = null
+/obj/item/circuit_component/pinpointer/Destroy()
+	target = null
 	return ..()
 
 /obj/item/circuit_component/pinpointer/input_received(datum/port/input/port)
 
 	var/atom/object = target.input_value
-	if(!object)
-		x_pos.set_output(null)
-		y_pos.set_output(null)
-		z_pos.set_output(null)
-		on_error.set_output(COMPONENT_SIGNAL)
-		return
 
 	var/turf/location = get_turf(object)
 
-	if(object.z != location.z || get_dist(location, object) > max_range)
-
-		x_pos.set_output(location?.x)
-		y_pos.set_output(location?.y)
-		z_pos.set_output(location?.z)
-	else
+	if(object.z != location.z || get_dist(location, object) < max_range || !object)
 		x_pos.set_output(null)
 		y_pos.set_output(null)
 		z_pos.set_output(null)
 		on_error.set_output(COMPONENT_SIGNAL)
-		return TRUE
+
+	else
+		x_pos.set_output(location?.x)
+		y_pos.set_output(location?.y)
+		z_pos.set_output(location?.z)
 

--- a/code/modules/wiremod/components/atom/pinpointer.dm
+++ b/code/modules/wiremod/components/atom/pinpointer.dm
@@ -5,8 +5,7 @@
  */
 /obj/item/circuit_component/pinpointer
 	display_name = "Proximity Pinpointer"
-	desc = "A component that returns the xyz co-ordinates of its entity input, as long as its in view."
-	category = "Entity"
+	display_desc = "A component that returns the xyz co-ordinates of its entity input, as long as its in view."
 
 	var/datum/port/input/target
 
@@ -19,7 +18,7 @@
 
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
-/obj/item/circuit_component/pinpointer/populate_ports()
+/obj/item/circuit_component/pinpointer/Initialize()
 	target = add_input_port("Target entity", PORT_TYPE_ATOM, FALSE)
 
 	x_pos = add_output_port("X", PORT_TYPE_NUMBER)
@@ -27,19 +26,24 @@
 	z_pos = add_output_port("Z", PORT_TYPE_NUMBER)
 	on_error = add_output_port("Failed", PORT_TYPE_SIGNAL)
 
+/obj/item/circuit_component/direction/Destroy()
+	input_port = null
+	output = null
+	return ..()
+
 /obj/item/circuit_component/pinpointer/input_received(datum/port/input/port)
 
-	if(isnull(target.value))
+	var/atom/object = target.input_value
+	if(!object)
 		x_pos.set_output(null)
 		y_pos.set_output(null)
 		z_pos.set_output(null)
 		on_error.set_output(COMPONENT_SIGNAL)
 		return
 
-	var/atom/target_entity = target.value
+	var/turf/location = get_turf(object)
 
-	if(is_in_sight(target_entity, get_location()) && IN_GIVEN_RANGE(get_location(), target_entity, max_range))
-		var/turf/location = get_turf(target_entity)
+	if(object.z != location.z || get_dist(location, object) > max_range)
 
 		x_pos.set_output(location?.x)
 		y_pos.set_output(location?.y)

--- a/code/modules/wiremod/components/atom/pinpointer.dm
+++ b/code/modules/wiremod/components/atom/pinpointer.dm
@@ -1,0 +1,53 @@
+/**
+ * # Proximity Pinpointer Component
+ *
+ * Return the location of its input.
+ */
+/obj/item/circuit_component/pinpointer
+	display_name = "Proximity Pinpointer"
+	desc = "A component that returns the xyz co-ordinates of its entity input, as long as its in view."
+	category = "Entity"
+
+	var/datum/port/input/target
+
+	var/datum/port/output/x_pos
+	var/datum/port/output/y_pos
+	var/datum/port/output/z_pos
+	var/datum/port/output/on_error
+
+	var/max_range = 7
+
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
+
+/obj/item/circuit_component/pinpointer/populate_ports()
+	target = add_input_port("Target entity", PORT_TYPE_ATOM, FALSE)
+
+	x_pos = add_output_port("X", PORT_TYPE_NUMBER)
+	y_pos = add_output_port("Y", PORT_TYPE_NUMBER)
+	z_pos = add_output_port("Z", PORT_TYPE_NUMBER)
+	on_error = add_output_port("Failed", PORT_TYPE_SIGNAL)
+
+/obj/item/circuit_component/pinpointer/input_received(datum/port/input/port)
+
+	if(isnull(target.value))
+		x_pos.set_output(null)
+		y_pos.set_output(null)
+		z_pos.set_output(null)
+		on_error.set_output(COMPONENT_SIGNAL)
+		return
+
+	var/atom/target_entity = target.value
+
+	if(is_in_sight(target_entity, get_location()) && IN_GIVEN_RANGE(get_location(), target_entity, max_range))
+		var/turf/location = get_turf(target_entity)
+
+		x_pos.set_output(location?.x)
+		y_pos.set_output(location?.y)
+		z_pos.set_output(location?.z)
+	else
+		x_pos.set_output(null)
+		y_pos.set_output(null)
+		z_pos.set_output(null)
+		on_error.set_output(COMPONENT_SIGNAL)
+		return TRUE
+

--- a/code/modules/wiremod/components/atom/pinpointer.dm
+++ b/code/modules/wiremod/components/atom/pinpointer.dm
@@ -37,6 +37,9 @@
 	return ..()
 
 /obj/item/circuit_component/pinpointer/input_received(datum/port/input/port)
+	. = ..()
+	if(.)
+		return
 
 	var/atom/object = target.input_value
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3742,6 +3742,7 @@
 #include "code\modules\wiremod\components\atom\gps.dm"
 #include "code\modules\wiremod\components\atom\health.dm"
 #include "code\modules\wiremod\components\atom\hear.dm"
+#include "code\modules\wiremod\components\atom\pinpointer.dm"
 #include "code\modules\wiremod\components\atom\self.dm"
 #include "code\modules\wiremod\components\atom\species.dm"
 #include "code\modules\wiremod\components\list\concat.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
added proximity pinpointer component that returns xyz co-ordinates of a entity

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
we finnaly can use pathfinding component
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: proximity pinpointer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
