### PR TITLE
A bunch of heretic fixes and improvements

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -432,14 +432,14 @@
 
 /datum/status_effect/eldritch/ash/on_creation(mob/living/new_owner, _repetition = 5)
 	. = ..()
-	repetitions = min(1,_repetition)
+	repetitions = max(1,_repetition)
 
 /datum/status_effect/eldritch/ash/on_effect()
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
 		carbon_owner.adjustStaminaLoss(10 * repetitions)
 		carbon_owner.adjustFireLoss(5 * repetitions)
-		for(var/mob/living/carbon/victim in range(1,carbon_owner))
+		for(var/mob/living/carbon/victim in shuffle(range(1,carbon_owner)))
 			if(IS_HERETIC(victim) || victim == carbon_owner)
 				continue
 			victim.apply_status_effect(type,repetitions-1)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1938,6 +1938,8 @@
  * Override this if you want custom behaviour in whatever gets hit by the rust
  */
 /atom/proc/rust_heretic_act()
+	if(HAS_TRAIT(src, TRAIT_RUSTY))
+		return
 	AddComponent(/datum/component/rust)
 
 /**

--- a/code/game/turfs/open/floor/iron_floor.dm
+++ b/code/game/turfs/open/floor/iron_floor.dm
@@ -17,9 +17,7 @@
 /turf/open/floor/iron/rust_heretic_act()
 	if(prob(70))
 		new /obj/effect/temp_visual/glowing_rune(src)
-	var/atom/changed_turf = ChangeTurf(/turf/open/floor/plating)
-	changed_turf.AddComponent(/datum/component/rust)
-	return ..()
+	ChangeTurf(/turf/open/floor/plating/rust)
 
 
 /turf/open/floor/iron/update_icon_state()

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -2,6 +2,7 @@
 	name = "Heretic"
 	roundend_category = "Heretics"
 	antagpanel_category = "Heretic"
+	ui_name = "AntagInfoHeretic"
 	antag_moodlet = /datum/mood_event/heretics
 	job_rank = ROLE_HERETIC
 	antag_hud_type = ANTAG_HUD_HERETIC
@@ -12,6 +13,13 @@
 	var/list/researched_knowledge = list()
 	var/total_sacrifices = 0
 	var/ascended = FALSE
+
+/datum/antagonist/heretic/ui_static_data(mob/user)
+	var/list/data = list()
+	data["total_sacrifices"] = total_sacrifices
+	data["ascended"] = ascended
+	data["objectives"] = get_objectives()
+	return data
 
 /datum/antagonist/heretic/admin_add(datum/mind/new_owner,mob/admin)
 	give_equipment = FALSE

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -104,7 +104,7 @@
 /datum/eldritch_knowledge/spell/flame_birth
 	name = "Flame Birth"
 	gain_text = "The Nightwatcher was a man of principles, and yet his power arose from the chaos he vowed to combat."
-	desc = "Short range spell that allows you to curse someone with massive sanity loss."
+	desc = "A spell that steals some health from every burning person around you."
 	cost = 1
 	spell_to_add = /obj/effect/proc_holder/spell/targeted/fiery_rebirth
 	next_knowledge = list(
@@ -137,7 +137,7 @@
 /datum/eldritch_knowledge/curse/corrosion
 	name = "Curse of Corrosion"
 	gain_text = "Cursed land, cursed man, cursed mind."
-	desc = "Curse someone for 2 minutes of vomiting and major organ damage. Using a wirecutter, a pool of blood, a heart, left arm and a right arm, and an item that the victim touched  with their bare hands."
+	desc = "Curse someone for 2 minutes of vomiting and major organ damage. Using a wirecutter, a pool of vomit, a heart and an item that the victim touched  with their bare hands."
 	cost = 1
 	required_atoms = list(/obj/item/wirecutters,/obj/effect/decal/cleanable/vomit,/obj/item/organ/heart)
 	next_knowledge = list(

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -201,7 +201,7 @@
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/stalker
 	next_knowledge = list(
 		/datum/eldritch_knowledge/summon/ashy,
-		/datum/eldritch_knowledge/summon/rusty,
+		/datum/eldritch_knowledge/spell/blood_siphon,
 		/datum/eldritch_knowledge/final/flesh_final
 	)
 	route = PATH_FLESH

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -73,20 +73,24 @@
 
 /datum/eldritch_knowledge/rust_regen/on_gain(mob/user)
 	. = ..()
-	RegisterSignal(user,COMSIG_MOVABLE_MOVED,.proc/on_move)
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/on_move)
 
 /datum/eldritch_knowledge/rust_regen/proc/on_move(mob/mover)
 	SIGNAL_HANDLER
 
-	var/atom/mover_turf = get_turf(mover)
+	var/turf/mover_turf = get_turf(mover)
 	if(HAS_TRAIT(mover_turf, TRAIT_RUSTY))
-		ADD_TRAIT(mover,TRAIT_STUNRESISTANCE,type)
+		ADD_TRAIT(mover, TRAIT_STUNRESISTANCE, type)
 		return
 
-	REMOVE_TRAIT(mover,TRAIT_STUNRESISTANCE,type)
+	REMOVE_TRAIT(mover, TRAIT_STUNRESISTANCE, type)
 
 /datum/eldritch_knowledge/rust_regen/on_life(mob/user)
 	. = ..()
+	var/turf/our_turf = get_turf(user)
+	if(!HAS_TRAIT(our_turf, TRAIT_RUSTY) || !isliving(user))
+		return
+		
 	var/mob/living/living_user = user
 	living_user.adjustBruteLoss(-2, FALSE)
 	living_user.adjustFireLoss(-2, FALSE)

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -41,7 +41,7 @@
 	. = ..()
 	if(ishuman(target))
 		var/mob/living/carbon/human/victim = target
-		var/datum/status_effect/eldritch/effect = victim.has_status_effect(/datum/status_effect/eldritch/rust) || victim.has_status_effect(/datum/status_effect/eldritch/ash) || victim.has_status_effect(/datum/status_effect/eldritch/flesh)  || victim.has_status_effect(/datum/status_effect/eldritch/void)
+		var/datum/status_effect/eldritch/effect = victim.has_status_effect(/datum/status_effect/eldritch/rust) || victim.has_status_effect(/datum/status_effect/eldritch/ash) || victim.has_status_effect(/datum/status_effect/eldritch/flesh) || victim.has_status_effect(/datum/status_effect/eldritch/void)
 		if(effect)
 			effect.on_effect()
 			victim.adjustOrganLoss(pick(ORGAN_SLOT_BRAIN,ORGAN_SLOT_EARS,ORGAN_SLOT_EYES,ORGAN_SLOT_LIVER,ORGAN_SLOT_LUNGS,ORGAN_SLOT_STOMACH,ORGAN_SLOT_HEART),25)
@@ -90,7 +90,7 @@
 	var/turf/our_turf = get_turf(user)
 	if(!HAS_TRAIT(our_turf, TRAIT_RUSTY) || !isliving(user))
 		return
-		
+
 	var/mob/living/living_user = user
 	living_user.adjustBruteLoss(-2, FALSE)
 	living_user.adjustFireLoss(-2, FALSE)
@@ -212,14 +212,20 @@
 /**
  * #Rust spread datum
  *
- * Simple datum that automatically spreads rust around it
+ * Simple datum that automatically spreads rust around it.
  *
- * Simple implementation of automatically growing entity
+ * Simple implementation of automatically growing entity.
  */
 /datum/rust_spread
-	var/list/edge_turfs = list()
-	var/list/turfs = list()
+	/// The rate of spread every tick.
+	var/spread_per_sec = 6
+	/// The very center of the spread.
 	var/turf/centre
+	/// List of turfs at the edge of our rust (but not yet rusted).
+	var/list/edge_turfs = list()
+	/// List of all turfs we've afflicted.
+	var/list/rusted_turfs = list()
+	/// Static blacklist of turfs we can't spread to.
 	var/static/list/blacklisted_turfs = typecacheof(list(
 		/turf/open/indestructible,
 		/turf/closed/indestructible,
@@ -227,54 +233,53 @@
 		/turf/open/lava,
 		/turf/open/chasm
 	))
-	var/spread_per_sec = 6
-
 
 /datum/rust_spread/New(loc)
-	. = ..()
 	centre = get_turf(loc)
 	centre.rust_heretic_act()
-	turfs += centre
-	START_PROCESSING(SSprocessing,src)
+	rusted_turfs += centre
+	START_PROCESSING(SSprocessing, src)
 
 /datum/rust_spread/Destroy(force, ...)
-	STOP_PROCESSING(SSprocessing,src)
+	centre = null
+	edge_turfs.Cut()
+	rusted_turfs.Cut()
+	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 
 /datum/rust_spread/process(delta_time)
-	var/spread_am = round(spread_per_sec * delta_time)
+	var/spread_amount = round(spread_per_sec * delta_time)
 
-	if(edge_turfs.len < spread_am)
+	if(length(edge_turfs) < spread_amount)
 		compile_turfs()
 
-	var/turf/rust_affected
-	for(var/i in 0 to spread_am)
-		if(!edge_turfs.len)
-			continue
-		rust_affected = pick(edge_turfs - turfs)
-		rust_affected.rust_heretic_act()
-		turfs += rust_affected
-
+	for(var/i in 0 to spread_amount)
+		if(!length(edge_turfs))
+			break
+		var/turf/afflicted_turf = pick_n_take(edge_turfs)
+		afflicted_turf.rust_heretic_act()
+		rusted_turfs |= afflicted_turf
 
 /**
  * Compile turfs
  *
- * Recreates all edge_turfs as well as normal turfs.
+ * Recreates the edge_turfs list.
+ * Updates the rusted_turfs list, in case any turfs within were un-rusted.
  */
 /datum/rust_spread/proc/compile_turfs()
-	edge_turfs = list()
-	var/list/removal_list = list()
-	var/max_dist = 1
-	for(var/atom/turfie as anything in turfs)
-		if(!HAS_TRAIT(turfie, TRAIT_RUSTY))
-			removal_list += turfie
-		max_dist = max(max_dist, get_dist(turfie,centre) +1)
-	turfs -= removal_list
-	for(var/turfie in spiral_range_turfs(max_dist,centre,FALSE))
+	edge_turfs.Cut()
 
-		if(turfie in turfs || is_type_in_typecache(turfie,blacklisted_turfs))
+	var/max_dist = 1
+	for(var/turf/found_turf as anything in rusted_turfs)
+		if(!HAS_TRAIT(found_turf, TRAIT_RUSTY))
+			rusted_turfs -= found_turf
+		max_dist = max(max_dist, get_dist(found_turf, centre) + 1)
+
+	for(var/turf/nearby_turf as anything in spiral_range_turfs(max_dist, centre, FALSE))
+		if(nearby_turf in rusted_turfs || is_type_in_typecache(nearby_turf, blacklisted_turfs))
 			continue
-		for(var/line_turfie_owo in getline(turfie,centre))
-			if(get_dist(turfie,line_turfie_owo) <= 1)
-				edge_turfs += turfie
+
+		for(var/turf/line_turf as anything in getline(nearby_turf, centre))
+			if(get_dist(nearby_turf, line_turf) <= 1)
+				edge_turfs |= nearby_turf
 		CHECK_TICK

--- a/tgui/packages/tgui/interfaces/AntagInfoHeretic.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoHeretic.tsx
@@ -1,0 +1,127 @@
+import { useBackend } from '../backend';
+import { Section, Stack, Box } from '../components';
+import { Window } from '../layouts';
+import { BooleanLike } from 'common/react';
+
+const hereticstyle = {
+  fontWeight: 'bold',
+  color: 'yellow',
+};
+
+type Objective = {
+  count: number;
+  name: string;
+  explanation: string;
+}
+
+type Info = {
+  total_sacrifices: number;
+  ascended: BooleanLike;
+  objectives: Objective[];
+};
+
+const ObjectivePrintout = (props, context) => {
+  const { data } = useBackend<Info>(context);
+  const {
+    objectives,
+  } = data;
+  return (
+    <Stack vertical>
+      <Stack.Item bold>
+        The old ones gave you these tasks to fulfill:
+      </Stack.Item>
+      <Stack.Item>
+        {!objectives && "None!"
+        || objectives.map(objective => (
+          <Stack.Item key={objective.count}>
+            {objective.count}: {objective.explanation}
+          </Stack.Item>
+        )) }
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+const InformationSection = (props, context) => {
+  const { data } = useBackend<Info>(context);
+  const {
+    total_sacrifices,
+    ascended,
+  } = data;
+  return (
+    <Stack vertical fill>
+      {!!ascended && (
+        <Stack.Item>
+          <Stack width="100%" justify="space-evenly" align="center" inline>
+            <Stack.Item>
+              You have
+            </Stack.Item>
+            <Stack.Item>
+              <Box inline fontSize="24px" color="red">ASCENDED</Box>
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
+      )}
+      <Stack.Item grow>
+        You have made a total of {total_sacrifices || 0} sacrifices.
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+const IntroductionSection = (props, context) => {
+  return (
+    <Stack
+      align="center"
+      justify="space-evenly"
+      height="100%"
+      width="100%"
+    >
+      <Stack.Item width="100%">
+        <Section title="You are the Heretic!" fill>
+          <Stack vertical fill>
+            <Stack.Item>
+              Another day at a meaningless job.
+              You feel a <Box inline color="red">shimmer</Box> around you,
+              as a realization of something <Box inline color="blue">strange</Box> in your backpack unfolds.
+              You look at it, unknowingly opening a new chapter in your life.
+              The <Box inline color="red">Gates of Mansus</Box> open up to your mind.
+              Their hand is at your throat, yet you see Them not.
+            </Stack.Item>
+            <Stack.Item>
+              <InformationSection />
+            </Stack.Item>
+            <Stack.Divider />
+            <Stack.Item grow>
+              <ObjectivePrintout />
+            </Stack.Item>
+          </Stack>
+        </Section>
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+export const AntagInfoHeretic = (props, context) => {
+  const { data } = useBackend<Info>(context);
+  const {
+    ascended,
+  } = data;
+  return (
+    <Window
+      width={620}
+      height={320}
+    >
+      <Window.Content
+        style={{
+          "background-image": "none",
+          "background": ascended
+            ? "radial-gradient(circle, rgba(24,9,9,1) 54%, rgba(31,10,10,1) 60%, rgba(46,11,11,1) 80%, rgba(47,14,14,1) 100%);"
+            : "radial-gradient(circle, rgba(9,9,24,1) 54%, rgba(10,10,31,1) 60%, rgba(21,11,46,1) 80%, rgba(24,14,47,1) 100%);",
+        }}
+      >
+        <IntroductionSection />
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/common/react.ts
+++ b/tgui/packages/tgui/interfaces/common/react.ts
@@ -1,0 +1,76 @@
+/**
+ * @file
+ * @copyright 2020 Aleksej Komarov
+ * @license MIT
+ */
+
+/**
+ * Helper for conditionally adding/removing classes in React
+ */
+export const classes = (classNames: (string | BooleanLike)[]) => {
+  let className = '';
+  for (let i = 0; i < classNames.length; i++) {
+    const part = classNames[i];
+    if (typeof part === 'string') {
+      className += part + ' ';
+    }
+  }
+  return className;
+};
+
+/**
+ * Normalizes children prop, so that it is always an array of VDom
+ * elements.
+ */
+export const normalizeChildren = <T>(children: T | T[]) => {
+  if (Array.isArray(children)) {
+    return children.flat().filter(value => value) as T[];
+  }
+  if (typeof children === 'object') {
+    return [children];
+  }
+  return [];
+};
+
+/**
+ * Shallowly checks if two objects are different.
+ * Credit: https://github.com/developit/preact-compat
+ */
+export const shallowDiffers = (a: object, b: object) => {
+  let i;
+  for (i in a) {
+    if (!(i in b)) {
+      return true;
+    }
+  }
+  for (i in b) {
+    if (a[i] !== b[i]) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Default inferno hooks for pure components.
+ */
+export const pureComponentHooks = {
+  onComponentShouldUpdate: (lastProps, nextProps) => {
+    return shallowDiffers(lastProps, nextProps);
+  },
+};
+
+/**
+ * A helper to determine whether the object is renderable by React.
+ */
+export const canRender = (value: unknown) => {
+  return value !== undefined
+    && value !== null
+    && typeof value !== 'boolean';
+};
+
+/**
+ * A common case in tgui, when you pass a value conditionally, these are
+ * the types that can fall through the condition.
+ */
+export type BooleanLike = number | boolean | null | undefined;


### PR DESCRIPTION
## About The Pull Request
Merges following ports from tg:
https://github.com/tgstation/tgstation/pull/60688
https://github.com/tgstation/tgstation/pull/60908
https://github.com/tgstation/tgstation/pull/61107
https://github.com/tgstation/tgstation/pull/63793
https://github.com/tgstation/tgstation/pull/64699
closes:https://github.com/The-Merchants-Guild/Merchant-Station-13/issues/273

## Why It's Good For The Game
More fixes and a heretic tgui antag panel

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: @MrMelbert @ViktorKoL @Watermelon914 @GoblinBackwards
fix: Rust Heretics now need to stand on Rust to heal again, instead of passive free healing
fix: corrected Fiery Rebirth's and Curse of Corrosion's heretic research descriptions
fix: fixed heretic research progression after unlocking the Lonely Ritual
qol: Heretic now has an antagonist panel
fix: Rust heretic ascension spread rusts everywhere again.
fix: Ash mark now deals the correct amount of damage and no longer gets stuck bouncing between the same two targets.
balance: Ash mark is significantly stronger due to this fix.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
