### PR TITLE
Anturk dmi change as separate PR

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
 		"arcanis.vscode-zipfs",
 		"dbaeumer.vscode-eslint",
 		"stylemistake.auto-comment-blocks",
-		"Donkie.vscode-tgstation-test-adapter"
+		"Donkie.vscode-tgstation-test-adapter",
+		"anturk.dmi-editor"
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,9 +12,6 @@
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": true
 	},
-	"workbench.editorAssociations": {
-		"*.dmi": "imagePreview.previewEditor"
-	},
 	"files.eol": "\n",
 	"files.insertFinalNewline": true,
 	"gitlens.advanced.blame.customArguments": ["-w"],


### PR DESCRIPTION
Here you go Etra

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Anturk DMI to vscode setup

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a purely coder-oriented change, doesn't change compilation, just makes it so you can stare at dmis in vscode with extra things to help you out instead of having to open dreammaker and break your dme
