### PR TITLE
Uplifts the limit on the cards

### DIFF
--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -11,12 +11,16 @@
  */
 
 /// Wildcard slot define for basic grey cards. Only hold 2 common wildcards.
-#define WILDCARD_LIMIT_GREY list(WILDCARD_NAME_COMMON = list(limit = 2, usage = list()))
+#define WILDCARD_LIMIT_GREY list( \
+	WILDCARD_NAME_COMMON = list(limit = -1, usage = list()), \
+	WILDCARD_NAME_COMMAND = list(limit = 17, usage = list()), \
+	WILDCARD_NAME_PRV_COMMAND = list(limit = 5, usage = list()) \
+)
 /// Wildcard slot define for Head of Staff silver cards. Can hold 3 common, 1 command and 1 private command.
 #define WILDCARD_LIMIT_SILVER list( \
-	WILDCARD_NAME_COMMON = list(limit = 3, usage = list()), \
-	WILDCARD_NAME_COMMAND = list(limit = 1, usage = list()), \
-	WILDCARD_NAME_PRV_COMMAND = list(limit = 1, usage = list()) \
+	WILDCARD_NAME_COMMON = list(limit = -1, usage = list()), \
+	WILDCARD_NAME_COMMAND = list(limit = 17, usage = list()), \
+	WILDCARD_NAME_PRV_COMMAND = list(limit = 5, usage = list()) \
 )
 /// Wildcard slot define for Captain gold cards. Can hold infinite of any Captain level wildcard.
 #define WILDCARD_LIMIT_GOLD list(WILDCARD_NAME_CAPTAIN = list(limit = -1, usage = list()))
@@ -30,9 +34,9 @@
 #define WILDCARD_LIMIT_PRISONER list()
 /// Wildcard slot define for Chameleon/Agent ID grey cards. Can hold 3 common, 1 command and 1 captain access.
 #define WILDCARD_LIMIT_CHAMELEON list( \
-	WILDCARD_NAME_COMMON = list(limit = 3, usage = list()), \
-	WILDCARD_NAME_COMMAND = list(limit = 1, usage = list()), \
-	WILDCARD_NAME_CAPTAIN = list(limit = 1, usage = list()) \
+	WILDCARD_NAME_COMMON = list(limit = -1, usage = list()), \
+	WILDCARD_NAME_COMMAND = list(limit = -1, usage = list()), \
+	WILDCARD_NAME_CAPTAIN = list(limit = -1, usage = list()) \
 )
 /// Wildcard slot define for admin/debug/weird, special abstract cards. Can hold infinite of any access.
 #define WILDCARD_LIMIT_ADMIN list(WILDCARD_NAME_ALL = list(limit = -1, usage = list()))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Matches the limit on access per card to the amount of access station has overall.
Does the same for common ID card, making silver and common card distinct only visually.
Additionally removes limits from chameleon card

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't know.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Silver and Regular id cards now have same access limits.
balance: Removed limits on chameleon card.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
