### PR TITLE
Removes chemical buffer bottles.

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -131,7 +131,6 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/reagent_containers/glass/beaker = 1,
 		/obj/item/reagent_containers/glass/rag = 1,
 		/obj/item/reagent_containers/hypospray/medipen/pumpup = 2,
-		/obj/item/reagent_containers/glass/bottle/random_buffer = 2,
 		) = 1,
 
 	list(//food

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -122,7 +122,6 @@
 	new /obj/item/storage/box/medigels(src)
 	new /obj/item/ph_booklet(src)
 	new /obj/item/reagent_containers/dropper(src)
-	new /obj/item/reagent_containers/glass/bottle/acidic_buffer(src) //hopefully they get the hint
 
 /obj/structure/closet/secure_closet/chemical/heisenberg //contains one of each beaker, syringe etc.
 	name = "advanced chemical closet"

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -38,7 +38,6 @@
 
 	glasses = /obj/item/clothing/glasses/science
 	belt = /obj/item/pda/chemist
-	l_pocket = /obj/item/reagent_containers/glass/bottle/random_buffer
 	r_pocket = /obj/item/reagent_containers/dropper
 	ears = /obj/item/radio/headset/headset_med
 	uniform = /obj/item/clothing/under/rank/medical/chemist

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -208,31 +208,6 @@
 	desc = "A small bottle of atropine."
 	list_reagents = list(/datum/reagent/medicine/atropine = 30)
 
-/obj/item/reagent_containers/glass/bottle/random_buffer
-	name = "Buffer bottle"
-	desc = "A small bottle of chemical buffer."
-
-/obj/item/reagent_containers/glass/bottle/random_buffer/Initialize()
-	. = ..()
-	if(prob(50))
-		name = "Acidic buffer bottle"
-		desc = "A small bottle of acidic buffer."
-		reagents.add_reagent(/datum/reagent/reaction_agent/acidic_buffer, 30)
-	else
-		name = "Basic buffer bottle"
-		desc = "A small bottle of basic buffer."
-		reagents.add_reagent(/datum/reagent/reaction_agent/basic_buffer, 30)
-
-/obj/item/reagent_containers/glass/bottle/acidic_buffer
-	name = "Acidic buffer bottle"
-	desc = "A small bottle of acidic buffer."
-	list_reagents = list(/datum/reagent/reaction_agent/acidic_buffer = 30)
-
-/obj/item/reagent_containers/glass/bottle/basic_buffer
-	name = "Basic buffer bottle"
-	desc = "A small bottle of basic buffer."
-	list_reagents = list(/datum/reagent/reaction_agent/basic_buffer = 30)
-
 /obj/item/reagent_containers/glass/bottle/romerol
 	name = "romerol bottle"
 	desc = "A small bottle of Romerol. The REAL zombie powder."


### PR DESCRIPTION
They are literally useless.
## Changelog
:cl:
del: Removed chemical buffer bottles as the PH doesn't matter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
