### PR TITLE
Return of Chemical Macros

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -149,8 +149,6 @@
 /datum/pipeline/proc/merge(datum/pipeline/parent_pipeline)
 	if(parent_pipeline == src)
 		return
-	if(!parent_pipeline)
-		return
 	air.volume += parent_pipeline.air.volume
 	members.Add(parent_pipeline.members)
 	for(var/obj/machinery/atmospherics/pipe/reference_pipe in parent_pipeline.members)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -149,6 +149,8 @@
 /datum/pipeline/proc/merge(datum/pipeline/parent_pipeline)
 	if(parent_pipeline == src)
 		return
+	if(!parent_pipeline)
+		return
 	air.volume += parent_pipeline.air.volume
 	members.Add(parent_pipeline.members)
 	for(var/obj/machinery/atmospherics/pipe/reference_pipe in parent_pipeline.members)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -366,7 +366,7 @@
 /obj/machinery/chem_dispenser/proc/process_recipe_list(recipe)
 	var/list/key_list = list()
 	var/list/final_list = list()
-	var/list/first_process = splittext(saved_recipes[recipe], ";")
+	var/list/first_process = splittext(recipe, ";")
 	for(var/reagents in first_process)
 		var/list/splitreagent = splittext(reagents, "=")
 		final_list[avoid_assoc_duplicate_keys(splitreagent[1], key_list)] = text2num(splitreagent[2])

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -222,7 +222,6 @@
 		data["beakerCurrentpH"] = null
 
 	var/chemicals[0]
-	var/list/recipes = list()
 	var/is_hallucinating = FALSE
 	if(user.hallucinating())
 		is_hallucinating = TRUE
@@ -234,9 +233,7 @@
 				chemname = "[pick_list_replacements("hallucination.json", "chemicals")]"
 			chemicals.Add(list(list("title" = chemname, "id" = ckey(temp.name), "pH" = temp.ph, "pHCol" = convert_ph_to_readable_color(temp.ph))))
 	data["chemicals"] = chemicals
-	for(var/recipe in saved_recipes)
-		recipes.Add(list(recipe))
-	data["recipes"] = recipes
+	data["recipes"] = saved_recipes
 
 	data["recipeReagents"] = list()
 	if(beaker?.reagents.ui_reaction_id)
@@ -289,7 +286,6 @@
 		if("dispense_recipe")
 			if(!is_operational || QDELETED(cell))
 				return
-			to_chat(world, span_announce("[params["recipe"]]"))
 			var/recipe_to_use = params["recipe"]
 			var/list/chemicals_to_dispense = process_recipe_list(recipe_to_use)
 			if(!LAZYLEN(chemicals_to_dispense))

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -289,6 +289,7 @@
 		if("dispense_recipe")
 			if(!is_operational || QDELETED(cell))
 				return
+			to_chat(world, span_announce("[params["recipe"]]"))
 			var/recipe_to_use = params["recipe"]
 			var/list/chemicals_to_dispense = process_recipe_list(recipe_to_use)
 			if(!LAZYLEN(chemicals_to_dispense))
@@ -366,10 +367,10 @@
 		if(amt % i == 0)
 			return TRUE
 
-/obj/machinery/chem_dispenser/proc/process_recipe_list(list/recipe)
+/obj/machinery/chem_dispenser/proc/process_recipe_list(recipe)
 	var/list/key_list = list()
 	var/list/final_list = list()
-	var/list/first_process = splittext(recipe, ";")
+	var/list/first_process = splittext(saved_recipes[recipe], ";")
 	for(var/reagents in first_process)
 		var/list/splitreagent = splittext(reagents, "=")
 		final_list[avoid_assoc_duplicate_keys(splitreagent[1], key_list)] = text2num(splitreagent[2])

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -287,7 +287,7 @@
 			replace_beaker(usr)
 			. = TRUE
 		if("dispense_recipe")
-			if(!is_operational)
+			if(!is_operational || QDELETED(cell))
 				return
 			var/recipe_to_use = params["recipe"]
 			var/list/chemicals_to_dispense = process_recipe_list(recipe_to_use)

--- a/tgui/packages/tgui/interfaces/ChemDispenser.js
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.js
@@ -83,7 +83,7 @@ export const ChemDispenser = (props, context) => {
                 <Button
                   icon="circle"
                   disabled={!data.isBeakerLoaded}
-                  content="Record"
+                  content="Add recipe"
                   onClick={() => act('record_recipe')} />
               )}
               {recording && (

--- a/tgui/packages/tgui/interfaces/ChemDispenser.js
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.js
@@ -111,7 +111,7 @@ export const ChemDispenser = (props, context) => {
                 lineHeight={1.75}
                 content={recipe.name}
                 onClick={() => act('dispense_recipe', {
-                  recipe: recipe.contents,
+                  recipe: recipe.name,
                 })} />
             ))}
             {recipes.length === 0 && (

--- a/tgui/packages/tgui/interfaces/ChemDispenser.js
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.js
@@ -111,7 +111,7 @@ export const ChemDispenser = (props, context) => {
                 lineHeight={1.75}
                 content={recipe.name}
                 onClick={() => act('dispense_recipe', {
-                  recipe: recipe.name,
+                  recipe: recipe.contents,
                 })} />
             ))}
             {recipes.length === 0 && (


### PR DESCRIPTION
Recording sucks balls and was added by or*nges, macros are better.
I need someone with TGUI skills to tell me why recipes still show up as this.
![image](https://user-images.githubusercontent.com/54416597/174948425-ecf78f63-dbd1-4daf-b67a-9f1459726447.png)


## Changelog
:cl:
add: Added the Chemical Macros back to chem dispensers. God bless powergamers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
