### PR TITLE
Gives Engiborgs ATMOS holofan barrier projectors

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -112,6 +112,14 @@
 	creation_time = 0
 	max_signs = 6
 
+/obj/item/holosign_creator/atmos/borg
+	name = "Cyborg ATMOS holofan projector"
+	desc = "A holographic projector that creates holographic barriers that prevent changes in atmosphere conditions. Can place up to 12 barriers"
+	icon_state = "signmaker_atmos"
+	holosign_type = /obj/structure/holosign/barrier/atmos
+	creation_time = 0
+	max_signs = 12
+
 /obj/item/holosign_creator/medical
 	name = "\improper PENLITE barrier projector"
 	desc = "A holographic projector that creates PENLITE holobarriers. Useful during quarantines since they halt those with malicious diseases."

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -274,7 +274,9 @@
 		/obj/item/stack/sheet/rglass/cyborg,
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/iron/base/cyborg,
-		/obj/item/stack/cable_coil)
+		/obj/item/stack/cable_coil,
+		/obj/item/holosign_creator/atmos
+		)
 	radio_channels = list(RADIO_CHANNEL_ENGINEERING)
 	emag_modules = list(/obj/item/borg/stun)
 	cyborg_base_icon = "engineer"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -275,7 +275,7 @@
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/iron/base/cyborg,
 		/obj/item/stack/cable_coil,
-		/obj/item/holosign_creator/atmos
+		/obj/item/holosign_creator/atmos/borg
 		)
 	radio_channels = list(RADIO_CHANNEL_ENGINEERING)
 	emag_modules = list(/obj/item/borg/stun)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives Engiborgs ATMOS holofan barrier projectors . Adds a specific variant for them that has 12 charges instead of 6.


## Why It's Good For The Game
Engiborgs can now do more to help with breaches, fires, and gas leaks. They can also build wacky stuff like Plasmamen habitats easier.

## Changelog
:cl:
add: Engineering borgs now start with ATMOS holofan projectors
/:cl:
