### PR TITLE
New Heretic Antag UI, Rune UI, Admin Buttons, New Path with new Side …

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -70,6 +70,9 @@
 #define PATH_VOID "Void"
 #define PATH_BLADE "Blade"
 
+/// A define used in ritual priority for heretics.
+#define MAX_KNOWLEDGE_PRIORITY 100
+
 /// Checks if the passed mob can become a heretic ghoul.
 /// - Must be a human (type, not species)
 /// - Skeletons cannot be husked (they are snowflaked instead of having a trait)

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -146,3 +146,7 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 	rhs = ispath(B, /datum/reagent) ? 0 : 1
 
 	return lhs - rhs
+
+/// Orders heretic knowledge by priority
+/proc/cmp_eldritch_knowledge(datum/eldritch_knowledge/knowledge_a, datum/eldritch_knowledge/knowledge_b)
+	return initial(knowledge_b.priority) - initial(knowledge_a.priority)

--- a/code/modules/antagonists/heretic/effects/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/effects/transmutation_rune.dm
@@ -1,30 +1,20 @@
+/// The heretic's rune, which they use to complete transmutation rituals.
 /obj/effect/eldritch
-	name = "Generic rune"
+	name = "transmutation rune"
 	desc = "A flowing circle of shapes and runes is etched into the floor, filled with a thick black tar-like fluid."
-	anchored = TRUE
 	icon_state = ""
+	anchored = TRUE
+	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = SIGIL_LAYER
 	///Used mainly for summoning ritual to prevent spamming the rune to create millions of monsters.
 	var/is_in_use = FALSE
 
-/obj/effect/eldritch/Initialize()
+/obj/effect/eldritch/Initialize(mapload)
 	. = ..()
-	var/image/I = image(icon = 'icons/effects/eldritch.dmi', icon_state = null, loc = src)
-	I.override = TRUE
-	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/silicons, "heretic_rune", I)
-
-/obj/effect/eldritch/attack_hand(mob/living/user, list/modifiers)
-	. = ..()
-	if(.)
-		return
-	try_activate(user)
-
-/obj/effect/eldritch/proc/try_activate(mob/living/user)
-	if(!IS_HERETIC(user))
-		return
-	if(!is_in_use)
-		INVOKE_ASYNC(src, .proc/activate , user)
+	var/image/silicon_image = image(icon = 'icons/effects/eldritch.dmi', icon_state = null, loc = src)
+	silicon_image.override = TRUE
+	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/silicons, "eldritch", silicon_image)
 
 /obj/effect/eldritch/attackby(obj/item/I, mob/living/user)
 	. = ..()
@@ -33,76 +23,169 @@
 		to_chat(user, span_danger("You disrupt the magic of [src] with [I]."))
 		qdel(src)
 
-/obj/effect/eldritch/proc/activate(mob/living/user)
+/obj/effect/eldritch/examine(mob/user)
+	. = ..()
+	if(!IS_HERETIC(user))
+		return
+
+	. += span_notice("Allows you to transmute objects by invoking the rune after collecting the prerequisites overhead.")
+	. += span_notice("You can use your <i>Codex Cicatrix</i> on the rune to remove it.")
+
+/obj/effect/eldritch/can_interact(mob/living/user)
+	. = ..()
+	if(!.)
+		return
+	if(!IS_HERETIC(user))
+		return FALSE
+	if(is_in_use)
+		return FALSE
+	return TRUE
+
+/obj/effect/eldritch/interact(mob/living/user)
+	. = ..()
+	INVOKE_ASYNC(src, .proc/try_rituals, user)
+	return TRUE
+
+/**
+ * Attempt to begin a ritual, giving them an input list to chose from.
+ * Also ensures is_in_use is enabled and disabled before and after.
+ */
+/obj/effect/eldritch/proc/try_rituals(mob/living/user)
 	is_in_use = TRUE
-	// Have fun trying to read this proc.
-	var/datum/antagonist/heretic/cultie = user.mind.has_antag_datum(/datum/antagonist/heretic)
-	var/list/knowledge = cultie.get_all_knowledge()
-	var/list/atoms_in_range = list()
 
-	for(var/A in range(1, src))
-		var/atom/atom_in_range = A
-		if(istype(atom_in_range,/area))
-			continue
-		if(istype(atom_in_range,/turf)) // we dont want turfs
-			continue
-		if(istype(atom_in_range,/mob/living))
-			var/mob/living/living_in_range = atom_in_range
-			if(living_in_range.stat != DEAD || living_in_range == user) // we only accept corpses, no living beings allowed.
-				continue
-		atoms_in_range += atom_in_range
-	for(var/X in knowledge)
-		var/datum/eldritch_knowledge/current_eldritch_knowledge = knowledge[X]
-
-		//has to be done so that we can freely edit the local_required_atoms without fucking up the eldritch knowledge
-		var/list/local_required_atoms = list()
-
-		if(!current_eldritch_knowledge.required_atoms || current_eldritch_knowledge.required_atoms.len == 0)
-			continue
-
-		local_required_atoms += current_eldritch_knowledge.required_atoms
-
-		var/list/selected_atoms = list()
-
-		if(!current_eldritch_knowledge.recipe_snowflake_check(atoms_in_range,drop_location(),selected_atoms))
-			continue
-
-		for(var/LR in local_required_atoms)
-			var/list/local_required_atom_list = LR
-
-			for(var/LAIR in atoms_in_range)
-				var/atom/local_atom_in_range = LAIR
-				if(is_type_in_list(local_atom_in_range,local_required_atom_list))
-					selected_atoms |= local_atom_in_range
-					local_required_atoms -= list(local_required_atom_list)
-					break
-
-		if(length(local_required_atoms) > 0)
-			continue
-
-		flick("[icon_state]_active",src)
-		playsound(user, 'sound/magic/castsummon.ogg', 75, TRUE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_exponent = 10)
-		//we are doing this since some on_finished_recipe subtract the atoms from selected_atoms making them invisible permanently.
-		var/list/atoms_to_disappear = selected_atoms.Copy()
-		for(var/to_disappear in atoms_to_disappear)
-			var/atom/atom_to_disappear = to_disappear
-			//temporary so we dont have to deal with the bs of someone picking those up when they may be deleted
-			atom_to_disappear.invisibility = INVISIBILITY_ABSTRACT
-		if(current_eldritch_knowledge.on_finished_recipe(user,selected_atoms,loc))
-			current_eldritch_knowledge.cleanup_atoms(selected_atoms)
-
-		for(var/to_appear in atoms_to_disappear)
-			var/atom/atom_to_appear = to_appear
-			//we need to reappear the item just in case the ritual didnt consume everything... or something.
-			atom_to_appear.invisibility = initial(atom_to_appear.invisibility)
-
+	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
+	var/list/rituals = heretic_datum.get_rituals()
+	if(!length(rituals))
+		user.balloon_alert(user, "no rituals available!")
 		is_in_use = FALSE
 		return
-	is_in_use = FALSE
-	to_chat(user,span_warning("Your ritual failed! You either used the wrong components or are missing something important!"))
 
+	var/chosen = tgui_input_list(user, "Chose a ritual to attempt.", "Chose a Ritual", rituals)
+	if(!chosen || !istype(rituals[chosen], /datum/eldritch_knowledge) || QDELETED(src) || QDELETED(user) || QDELETED(heretic_datum))
+		is_in_use = FALSE
+		return
+
+	do_ritual(user, rituals[chosen])
+	is_in_use = FALSE
+
+/**
+ * Attempt to invoke a ritual from the past list of knowledges.
+ *
+ * Arguments
+ * * user - the heretic / the person who invoked the rune
+ * * knowledge_list - a non-assoc list of eldritch_knowledge datums.
+ *
+ * returns TRUE if any rituals passed succeeded, FALSE if they all failed.
+ */
+/obj/effect/eldritch/proc/do_ritual(mob/living/user, datum/eldritch_knowledge/ritual)
+
+	// Collect all nearby valid atoms over the rune for processing in rituals.
+	var/list/atom/movable/atoms_in_range = list()
+	for(var/atom/close_atom as anything in range(1, src))
+		if(!ismovable(close_atom))
+			continue
+		if(close_atom.invisibility)
+			continue
+		if(close_atom == user)
+			continue
+
+		atoms_in_range += close_atom
+
+	// A copy of our requirements list.
+	// We decrement the values of to determine if enough of each key is present.
+	var/list/requirements_list = ritual.required_atoms.Copy()
+	// A list of all atoms we've selected to use in this recipe.
+	var/list/selected_atoms = list()
+
+	// Do the snowflake check to see if we can continue or not.
+	// selected_atoms is passed and can be modified by this proc.
+	if(!ritual.recipe_snowflake_check(user, atoms_in_range, selected_atoms, loc))
+		return FALSE
+
+	// Now go through all our nearby atoms and see which are good for our ritual.
+	for(var/atom/nearby_atom as anything in atoms_in_range)
+		// Go through all of our required atoms
+		for(var/req_type in requirements_list)
+			// We already have enough of this type, skip
+			if(requirements_list[req_type] <= 0)
+				continue
+			if(!istype(nearby_atom, req_type))
+				continue
+
+			// This item is a valid type. Add it to our selected atoms list.
+			selected_atoms |= nearby_atom
+			// If it's a stack, we gotta see if it has more than one inside,
+			// as our requirements may want more than one item of a stack
+			if(isstack(nearby_atom))
+				var/obj/item/stack/picked_stack = nearby_atom
+				requirements_list[req_type] -= picked_stack.amount // Can go negative, but doesn't matter. Negative = fulfilled
+
+			// Otherwise, just add the mark down the item as fulfilled x1
+			else
+				requirements_list[req_type]--
+
+	// All of the atoms have been checked, let's see if the ritual was successful
+	var/list/what_are_we_missing = list()
+	for(var/atom/req_type as anything in requirements_list)
+		var/number_of_things = requirements_list[req_type]
+		// <= 0 means it's fulfilled, skip
+		if(number_of_things <= 0)
+			continue
+
+		// > 0 means it's unfilfilled - the ritual has failed, we should tell them why
+		// Lets format the thing they're missing and put it into our list
+		var/formatted_thing = "[number_of_things] [initial(req_type.name)]\s"
+		if(ispath(req_type, /mob/living/carbon/human))
+			// If we need a human, there is a high likelihood we actually need a (dead) body
+			formatted_thing = "[number_of_things] [number_of_things > 1 ? "bodies":"body"]"
+
+		what_are_we_missing += formatted_thing
+
+	if(length(what_are_we_missing))
+		// Let them know it screwed up
+		user.balloon_alert(user, "ritual failed, missing components!")
+		// Then let them know what they're missing
+		to_chat(user, span_hierophant_warning("You are missing [english_list(what_are_we_missing)] in order to complete the ritual \"[ritual.name]\"."))
+		return FALSE
+
+	// If we made it here, the ritual had all necessary components, and we can try to cast it.
+	// This doesn't necessarily mean the ritual will succeed, but it's valid!
+	// Do the animations and associated feedback.
+	flick("[icon_state]_active", src)
+	playsound(user, 'sound/magic/castsummon.ogg', 75, TRUE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_exponent = 10)
+
+	// - We temporarily make all of our chosen atoms invisible, as some rituals may sleep,
+	// and we don't want people to be able to run off with ritual items.
+	// - We make a duplicate list here to ensure that all atoms are correctly un-invisibled by the end.
+	// Some rituals may remove atoms from the selected_atoms list, and not consume them.
+	var/list/initial_selected_atoms = selected_atoms.Copy()
+	for(var/atom/to_disappear as anything in selected_atoms)
+		to_disappear.invisibility = INVISIBILITY_ABSTRACT
+
+	// All the components have been invisibled, time to actually do the ritual. Call on_finished_recipe
+	// (Note: on_finished_recipe may sleep in the case of some rituals like summons, which expect ghost candidates.)
+	// - If the ritual was success (Returned TRUE), proceede to clean up the atoms involved in the ritual. The result has already been spawned by this point.
+	// - If the ritual failed for some reason (Returned FALSE), likely due to no ghosts taking a role or an error, we shouldn't clean up anything, and reset.
+	var/ritual_result = ritual.on_finished_recipe(user, selected_atoms, loc)
+	if(ritual_result)
+		ritual.cleanup_atoms(selected_atoms)
+
+	// Clean up done, re-appear anything that hasn't been deleted.
+	for(var/atom/to_appear as anything in initial_selected_atoms)
+		if(QDELETED(to_appear))
+			continue
+		to_appear.invisibility = initial(to_appear.invisibility)
+
+	// And finally, give some user feedback
+	// No feedback is given on failure here -
+	// the ritual itself should handle it (providing specifics as to why it failed)
+	if(ritual_result)
+		user.balloon_alert(user, "ritual complete")
+
+	return ritual_result
+
+/// A 3x3 heretic rune. The kind heretics actually draw in game.
 /obj/effect/eldritch/big
-	name = "transmutation rune"
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "eldritch_rune1"
 	pixel_x = -32 //So the big ol' 96x96 sprite shows up right

--- a/code/modules/antagonists/heretic/eldritch_antag.dm
+++ b/code/modules/antagonists/heretic/eldritch_antag.dm
@@ -75,6 +75,22 @@
 
 	return ..()
 
+/*
+ * Get a list of all rituals this heretic can invoke on a rune.
+ * Iterates over all of our knowledge and, if we can invoke it, adds it to our list.
+ *
+ * Returns an associated list of [knowledge name] to [knowledge datum] sorted by knowledge priority.
+*/
+/datum/antagonist/heretic/proc/get_rituals()
+	var/list/rituals = list()
+	for(var/knowledge_index in researched_knowledge)
+		var/datum/eldritch_knowledge/knowledge = researched_knowledge[knowledge_index]
+		if(!knowledge.can_be_invoked(src))
+			continue
+		rituals[knowledge.name] = knowledge
+
+	return sortTim(rituals, /proc/cmp_eldritch_knowledge, associative = TRUE)
+
 /datum/antagonist/heretic/process()
 
 	if(owner.current.stat == DEAD)

--- a/code/modules/antagonists/heretic/eldritch_demons/mirror_walk.dm
+++ b/code/modules/antagonists/heretic/eldritch_demons/mirror_walk.dm
@@ -19,7 +19,7 @@
 	loot = list(
 		/obj/item/shard,
 		/obj/effect/decal/cleanable/ash,
-		/obj/item/clothing/suit/armor,
+		/obj/item/clothing/under/costume/maid,
 		/obj/item/organ/lungs,
 	)
 	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/mirror_walk)

--- a/code/modules/antagonists/heretic/items/hunter_rifle.dm
+++ b/code/modules/antagonists/heretic/items/hunter_rifle.dm
@@ -45,7 +45,7 @@
 		return TRUE
 
 	if(currently_aiming)
-		to_chat(user, span_warning("Already aiming!"))
+		user.balloon_alert(user, "Already aiming!")
 		return FALSE
 
 	var/distance = get_dist(user, target)
@@ -54,7 +54,7 @@
 	if(distance <= min_distance || !isliving(target))
 		return TRUE
 
-	to_chat(user, span_warning("taking aim..."))
+	user.balloon_alert(user, "taking aim...")
 	user.playsound_local(get_turf(user), 'sound/weapons/gun/general/chunkyrack.ogg', 100, TRUE)
 
 	var/image/reticle = image(
@@ -85,7 +85,7 @@
 		viewer.client?.images -= reticle
 
 	if(!.)
-		to_chat(user, span_warning("interrupted!"))
+		user.balloon_alert(user, "interrupted!")
 
 	return .
 

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -163,13 +163,10 @@
 	)
 
 /datum/eldritch_knowledge/final/ash_final/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
+	. = ..()
 	priority_announce("[generate_eldritch_text()] Fear the blaze, for the Ashlord, [user.real_name] has ascended! The flames shall consume all! [generate_eldritch_text()]","[generate_eldritch_text()]", ANNOUNCER_SPANOMALIES)
 	user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/fire_cascade/big)
 	user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/fire_sworn)
-	var/mob/living/carbon/human/ascendant = user
-	ascendant.physiology.brute_mod *= 0.5
-	ascendant.physiology.burn_mod *= 0.5
-	ascendant.client?.give_award(/datum/award/achievement/misc/ash_ascension, ascendant)
+	user.client?.give_award(/datum/award/achievement/misc/ash_ascension, user)
 	for(var/trait in trait_list)
 		ADD_TRAIT(user, trait, MAGIC_TRAIT)
-	return ..()

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -325,7 +325,7 @@
 		at a target, dealing damage and causing bleeding."
 	gain_text = "His arts were those that ensured an ending."
 	next_knowledge = list(
-		/datum/eldritch_knowledge/summon/maid_in_mirror,
+		/datum/eldritch_knowledge/summon/maid_in_the_mirror,
 		/datum/eldritch_knowledge/final/blade_final,
 		/datum/eldritch_knowledge/rifle,
 	)

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -124,14 +124,15 @@
 		// We'll select any valid bodies here. If they're clientless, we'll give them a new one.
 		selected_atoms += body
 		return TRUE
-	to_chat(user, span_warning("Ritual failed, no valid body!"))
+
+	user.balloon_alert(user, "ritual failed, no valid body!")
 	return FALSE
 
 /datum/eldritch_knowledge/limited_amount/flesh_ghoul/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	var/mob/living/carbon/human/soon_to_be_ghoul = locate() in selected_atoms
 	if(QDELETED(soon_to_be_ghoul)) // No body? No ritual
 		stack_trace("[type] reached on_finished_recipe without a human in selected_atoms to make a ghoul out of.")
-		to_chat(user, span_warning("Ritual failed, no valid body!"))
+		user.balloon_alert(user, "ritual failed, no valid body!")
 		return FALSE
 
 	soon_to_be_ghoul.grab_ghost()
@@ -140,7 +141,7 @@
 		message_admins("[ADMIN_LOOKUPFLW(user)] is creating a voiceless dead of a body with no player.")
 		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [soon_to_be_ghoul.real_name], a voiceless dead?", ROLE_HERETIC, ROLE_HERETIC, 5 SECONDS, soon_to_be_ghoul)
 		if(!LAZYLEN(candidates))
-			to_chat(user, span_warning("Ritual failed, no ghosts!"))
+			user.balloon_alert(user, "ritual failed, no ghosts!")
 			return FALSE
 
 		var/mob/dead/observer/chosen_candidate = pick(candidates)
@@ -255,16 +256,12 @@
 	desc = "Bring 3 bodies onto a transmutation rune to shed your human form and ascend to untold power."
 	route = PATH_FLESH
 
-/datum/eldritch_knowledge/final/flesh_final/on_finished_recipe(mob/living/user, list/atoms, loc)
+/datum/eldritch_knowledge/final/flesh_final/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = ..()
-	priority_announce("[generate_eldritch_text()] Ever coiling vortex. Reality unfolded. THE LORD OF ARMS, [user.real_name] has ascended! Fear the ever twisting hand! [generate_eldritch_text()]","[generate_eldritch_text()]", ANNOUNCER_SPANOMALIES)
+	priority_announce("[generate_eldritch_text()] Ever coiling vortex. Reality unfolded. ARMS OUTREACHED, THE LORD OF THE NIGHT, [user.real_name] has ascended! Fear the ever twisting hand! [generate_eldritch_text()]", "[generate_eldritch_text()]", ANNOUNCER_SPANOMALIES)
 	user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shed_human_form)
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/lord_of_arms = user
-	lord_of_arms.physiology.brute_mod *= 0.5
-	lord_of_arms.physiology.burn_mod *= 0.5
-	lord_of_arms.client?.give_award(/datum/award/achievement/misc/flesh_ascension, lord_of_arms)
+	user.client?.give_award(/datum/award/achievement/misc/flesh_ascension, user)
+
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
 	var/datum/eldritch_knowledge/limited_amount/flesh_grasp/grasp_ghoul = heretic_datum.get_knowledge(/datum/eldritch_knowledge/limited_amount/flesh_grasp)
 	grasp_ghoul.limit *= 3

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -25,26 +25,29 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 		/datum/eldritch_knowledge/starting/base_void,
 		)
 	cost = 0
+	priority = MAX_KNOWLEDGE_PRIORITY - 1 // Sacrifice will be the most important
 	spell_to_add = /obj/effect/proc_holder/spell/targeted/touch/mansus_grasp
 	required_atoms = list(/obj/item/living_heart)
 	route = PATH_START
 
-/datum/eldritch_knowledge/spell/basic/recipe_snowflake_check(list/atoms, loc)
+/datum/eldritch_knowledge/spell/basic/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
 	. = ..()
 	for(var/obj/item/living_heart/heart in atoms)
 		if(!heart.target)
+			selected_atoms += heart
 			return TRUE
 		if(heart.target in atoms)
+			selected_atoms += heart
 			return TRUE
 	return FALSE
 
-/datum/eldritch_knowledge/spell/basic/on_finished_recipe(mob/living/user, list/atoms, loc)
+/datum/eldritch_knowledge/spell/basic/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = TRUE
 	var/mob/living/carbon/carbon_user = user
-	for(var/obj/item/living_heart/heart in atoms)
+	for(var/obj/item/living_heart/heart in selected_atoms)
 
 		if(heart.target && heart.target.stat == DEAD)
-			to_chat(carbon_user,span_danger("Your patrons accepts your offer.."))
+			user.balloon_alert(user, "Your patrons accepts your offer..")
 			var/mob/living/carbon/human/current_target = heart.target
 			current_target.gib()
 			heart.target = null
@@ -79,18 +82,17 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 			heart.target = targets[input(user,"Choose your next target","Target") in targets]
 			qdel(temp_objective)
 			if(heart.target)
-				to_chat(user,span_warning("Your new target has been selected, go and sacrifice [heart.target.real_name]!"))
+				user.balloon_alert(user, "Your new target has been selected, go and sacrifice [heart.target.real_name]!")
 			else
-				to_chat(user, span_warning("target could not be found for living heart."))
-
-/datum/eldritch_knowledge/spell/basic/cleanup_atoms(list/atoms)
-	return
+				user.balloon_alert(user, "Target could not be found for living heart.")
+				return FALSE
 
 /datum/eldritch_knowledge/living_heart
 	name = "Living Heart"
 	desc = "Allows you to create additional living hearts, using a heart, a pool of blood and a poppy. Living hearts when used on a transmutation rune will grant you a person to hunt and sacrifice on the rune. Every sacrifice gives you an additional charge in the book."
 	gain_text = "The Gates of Mansus open up to your mind."
 	cost = 0
+	priority = MAX_KNOWLEDGE_PRIORITY - 2 // Knowing how to remake your heart is important
 	required_atoms = list(
 		/obj/item/organ/heart = 1,
 		/obj/effect/decal/cleanable/blood = 1,
@@ -104,6 +106,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	desc = "Allows you to create a spare Codex Cicatrix if you have lost one, using a bible, human skin, a pen and a pair of eyes."
 	gain_text = "Their hand is at your throat, yet you see Them not."
 	cost = 0
+	priority = MAX_KNOWLEDGE_PRIORITY - 3 // Not as important as making a heart or sacrificing, but important enough.
 	required_atoms = list(
 		/obj/item/organ/eyes = 1,
 		/obj/item/stack/sheet/animalhide/human = 1,

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -141,7 +141,7 @@
 	next_knowledge = list(
 		/datum/eldritch_knowledge/final/void_final,
 		/datum/eldritch_knowledge/spell/cleave,
-		/datum/eldritch_knowledge/summon/maid_in_mirror,
+		/datum/eldritch_knowledge/summon/maid_in_the_mirror,
 	)
 	route = PATH_VOID
 

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -26,6 +26,15 @@
 //Signal for the Sharpening Edge gets the Listener from /datum/eldritch_knowledge/proc/on_gain(mob/user)
 /obj/item/melee/touch_attack/mansus_fist/attackby(obj/item/I, mob/user, params)
 	if(SEND_SIGNAL(user, COMSIG_HERETIC_BLADE_MANIPULATION, src) & COMPONENT_SHARPEN)
+		if(istype(I,/obj/item/nullrod/))
+			var/mob/living/carbon/Cuser = user
+			var/obj/item/bodypart/holding_bodypart = Cuser.get_holding_bodypart_of_item(src)
+			to_chat(user, span_warning("You attempted to sharpen a holy weapon!"))
+			explosion(src, devastation_range = -1, heavy_impact_range = -2, light_impact_range = 1, flame_range = 1, flash_range = 1)
+			playsound(user, hitsound, 25, TRUE)
+			holding_bodypart.dismember(BURN)
+			Cuser.adjustFireLoss(20)
+			return
 		eldritch_whetstone.activate(user, I)
 
 /obj/item/melee/touch_attack/mansus_fist/afterattack(atom/target, mob/user, proximity_flag, click_parameters)

--- a/code/modules/antagonists/heretic/side_paths/ash_flesh.dm
+++ b/code/modules/antagonists/heretic/side_paths/ash_flesh.dm
@@ -7,17 +7,25 @@
 		/datum/eldritch_knowledge/spell/ashen_shift,
 		/datum/eldritch_knowledge/limited_amount/flesh_ghoul
 		)
-	required_atoms = list(/obj/item/organ/eyes,/obj/item/shard)
+	required_atoms = list(
+		/obj/item/organ/eyes = 1,
+		/obj/item/shard = 1)
 	result_atoms = list(/obj/item/clothing/neck/eldritch_amulet)
+	route = PATH_SIDE
 
 /datum/eldritch_knowledge/curse/paralysis
 	name = "Curse of Paralysis"
 	gain_text = "Corrupt their flesh, make them bleed."
 	desc = "Curse someone for 5 minutes of inability to walk. Sacrifice a knife, a pool of blood, a pair of legs, a hatchet and an item that the victim touched with their bare hands. "
 	cost = 1
-	required_atoms = list(/obj/item/bodypart/l_leg,/obj/item/bodypart/r_leg,/obj/item/hatchet)
+	required_atoms = list(
+		/obj/item/bodypart/l_leg = 1,
+		/obj/item/bodypart/r_leg = 1,
+		/obj/item/hatchet = 1
+		)
 	next_knowledge = list(/datum/eldritch_knowledge/mad_mask,/datum/eldritch_knowledge/summon/raw_prophet)
 	timer = 5 MINUTES
+	route = PATH_SIDE
 
 /datum/eldritch_knowledge/curse/paralysis/curse(mob/living/chosen_mob)
 	. = ..()
@@ -35,9 +43,14 @@
 	gain_text = "I combined my principle of hunger with my desire for destruction. And the Nightwatcher knew my name."
 	desc = "You can now summon an Ash Man by transmutating a pile of ash, a head and a book."
 	cost = 1
-	required_atoms = list(/obj/effect/decal/cleanable/ash,/obj/item/bodypart/head,/obj/item/book)
+	required_atoms = list(
+		/obj/effect/decal/cleanable/ash = 1,
+		/obj/item/bodypart/head = 1,
+		/obj/item/book = 1
+		)
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/ash_spirit
 	next_knowledge = list(/datum/eldritch_knowledge/summon/stalker,/datum/eldritch_knowledge/spell/flame_birth)
+	route = PATH_SIDE
 
 /datum/eldritch_knowledge/summon/ashy/cleanup_atoms(list/selected_atoms)
 	var/obj/item/bodypart/head/ritual_head = locate() in selected_atoms

--- a/code/modules/antagonists/heretic/side_paths/flesh_void.dm
+++ b/code/modules/antagonists/heretic/side_paths/flesh_void.dm
@@ -5,7 +5,12 @@
 	cost = 1
 	next_knowledge = list(/datum/eldritch_knowledge/limited_amount/flesh_ghoul,/datum/eldritch_knowledge/cold_snap)
 	result_atoms = list(/obj/item/clothing/suit/hooded/cultrobes/void)
-	required_atoms = list(/obj/item/shard,/obj/item/clothing/suit,/obj/item/bedsheet)
+	required_atoms = list(
+		/obj/item/shard = 1,
+		/obj/item/clothing/suit = 1,
+		/obj/item/bedsheet = 1,
+		)
+	route = PATH_SIDE
 
 /datum/eldritch_knowledge/spell/blood_siphon
 	name = "Blood Siphon"
@@ -14,6 +19,7 @@
 	cost = 1
 	spell_to_add = /obj/effect/proc_holder/spell/pointed/blood_siphon
 	next_knowledge = list(/datum/eldritch_knowledge/summon/stalker,/datum/eldritch_knowledge/spell/voidpull)
+	route = PATH_SIDE
 
 /datum/eldritch_knowledge/spell/cleave
 	name = "Blood Cleave"
@@ -22,3 +28,4 @@
 	cost = 1
 	spell_to_add = /obj/effect/proc_holder/spell/pointed/cleave
 	next_knowledge = list(/datum/eldritch_knowledge/spell/entropic_plume,/datum/eldritch_knowledge/spell/flame_birth)
+	route = PATH_SIDE

--- a/code/modules/antagonists/heretic/side_paths/rust_ash.dm
+++ b/code/modules/antagonists/heretic/side_paths/rust_ash.dm
@@ -4,20 +4,29 @@
 	gain_text = "This is an old recipe. The Owl whispered it to me."
 	cost = 1
 	next_knowledge = list(/datum/eldritch_knowledge/rust_regen,/datum/eldritch_knowledge/spell/ashen_shift)
-	required_atoms = list(/obj/structure/reagent_dispensers/watertank,/obj/item/shard)
+	required_atoms = list(
+		/obj/structure/reagent_dispensers/watertank,
+		/obj/item/shard = 1,
+		)
 	result_atoms = list(/obj/item/reagent_containers/glass/beaker/eldritch)
+	route = PATH_SIDE
 
 /datum/eldritch_knowledge/curse/corrosion
 	name = "Curse of Corrosion"
 	gain_text = "Cursed land, cursed man, cursed mind."
 	desc = "Curse someone for 2 minutes of vomiting and major organ damage. Using a wirecutter, a pool of vomit, a heart and an item that the victim touched  with their bare hands."
 	cost = 1
-	required_atoms = list(/obj/item/wirecutters,/obj/effect/decal/cleanable/vomit,/obj/item/organ/heart)
+	required_atoms = list(
+		/obj/item/wirecutters = 1,
+		/obj/effect/decal/cleanable/vomit = 1,
+		/obj/item/organ/heart = 1,
+		)
 	next_knowledge = list(
 		/datum/eldritch_knowledge/mad_mask,
 		/datum/eldritch_knowledge/spell/area_conversion
 	)
 	timer = 2 MINUTES
+	route = PATH_SIDE
 
 /datum/eldritch_knowledge/curse/corrosion/curse(mob/living/chosen_mob)
 	. = ..()
@@ -32,9 +41,14 @@
 	gain_text = "I combined my principle of hunger with my desire for corruption. And the Rusted Hills called my name."
 	desc = "You can now summon a Rust Walker by transmutating a vomit pool, a severed head and a book."
 	cost = 1
-	required_atoms = list(/obj/effect/decal/cleanable/vomit,/obj/item/book,/obj/item/bodypart/head)
+	required_atoms = list(
+		/obj/effect/decal/cleanable/vomit = 1,
+		/obj/item/book = 1,
+		/obj/item/bodypart/head = 1
+		)
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/rust_spirit
 	next_knowledge = list(/datum/eldritch_knowledge/spell/voidpull,/datum/eldritch_knowledge/spell/entropic_plume)
+	route = PATH_SIDE
 
 /datum/eldritch_knowledge/summon/rusty/cleanup_atoms(list/selected_atoms)
 	var/obj/item/bodypart/head/ritual_head = locate() in selected_atoms

--- a/code/modules/antagonists/heretic/side_paths/void_blade.dm
+++ b/code/modules/antagonists/heretic/side_paths/void_blade.dm
@@ -46,20 +46,20 @@
 		selected_atoms += body
 		return TRUE
 
-	to_chat(user, span_warning("Ritual failed, no valid body!"))
+	user.balloon_alert(user, "ritual failed, no valid body!")
 	return FALSE
 
 /datum/eldritch_knowledge/limited_amount/risen_corpse/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	var/mob/living/carbon/human/soon_to_be_ghoul = locate() in selected_atoms
 	if(QDELETED(soon_to_be_ghoul)) // No body? No ritual
 		stack_trace("[type] reached on_finished_recipe without a human in selected_atoms to make a ghoul out of.")
-		to_chat(user, span_warning("Ritual failed, no valid body!"))
+		user.balloon_alert(user, "ritual failed, no valid body!")
 		return FALSE
 
 	soon_to_be_ghoul.grab_ghost()
 	if(!soon_to_be_ghoul.mind || !soon_to_be_ghoul.client)
 		stack_trace("[type] reached on_finished_recipe without a minded / cliented human in selected_atoms to make a ghoul out of.")
-		to_chat(user, span_warning("Ritual failed, no valid body!"))
+		user.balloon_alert(user, "ritual failed, no valid body!")
 		return FALSE
 
 	selected_atoms -= soon_to_be_ghoul
@@ -149,7 +149,7 @@
 	cost = 1
 	route = PATH_SIDE
 
-/datum/eldritch_knowledge/summon/maid_in_mirror
+/datum/eldritch_knowledge/summon/maid_in_the_mirror
 	name = "Maid in the Mirror"
 	desc = "Allows you to transmute five sheets of titanium, a flash, a suit of armor, and a pair of lungs \
 		to create a Maid in the Mirror. Maid in the Mirrors are decent combatants that can become incorporeal by \

--- a/code/modules/unit_tests/heretic_knowledge.dm
+++ b/code/modules/unit_tests/heretic_knowledge.dm
@@ -1,21 +1,92 @@
-/// This test checks all heretic knowledge nodes - excluding the ones which are unreachable on purpose - and ensures players can reach them in game.
-/// If it finds a node that is unreachable, it throws an error.
-/datum/unit_test/heretic_knowledge/Run()
-	///List of all knowledge excluding the unreachable base types.
-	var/list/blacklist = list(/datum/eldritch_knowledge/spell,/datum/eldritch_knowledge/curse,/datum/eldritch_knowledge/final,/datum/eldritch_knowledge/summon,/datum/eldritch_knowledge/starting,/datum/eldritch_knowledge/blade_upgrade,/datum/eldritch_knowledge/mark,/datum/eldritch_knowledge/limited_amount)
-	var/list/all_possible_knowledge = subtypesof(/datum/eldritch_knowledge) - blacklist
+/*
+ * This test checks all heretic knowledge nodes and validates they are setup correctly.
+ * We check that all knowledge is reachable by players (through the research tree)
+ * and that all knowledge have a valid next_knowledge list.
+ */
+/datum/unit_test/heretic_knowledge
 
+/datum/unit_test/heretic_knowledge/Run()
+
+	// First, we get a list of all knowledge types
+	// EXCLUDING types which have route unset / set to null.
+	// (Types without a route set are assumed to be abstract or purposefully unreachable)
+	var/list/all_possible_knowledge = typesof(/datum/eldritch_knowledge)
+	for(var/datum/eldritch_knowledge/knowledge_type as anything in all_possible_knowledge)
+		if(isnull(initial(knowledge_type.route)))
+			all_possible_knowledge -= knowledge_type
+
+	// Now, let's build a list of all researchable knowledge
+	// from the ground up. We start with all starting knowledge,
+	// then add the next possible knowledges back into the list
+	// repeatedly, until we run out of knowledges to add.
 	var/list/list_to_check = GLOB.heretic_start_knowledge.Copy()
 	var/i = 0
 	while(i < length(list_to_check))
-		var/datum/eldritch_knowledge/eldritch_knowledge = allocate(list_to_check[++i])
-		for(var/next_knowledge in eldritch_knowledge.next_knowledge)
+		var/datum/eldritch_knowledge/path_to_create = list_to_check[++i]
+		if(!ispath(path_to_create))
+			Fail("Heretic Knowlege: Got a non-heretic knowledge datum (Got: [path_to_create]) in the list knowledges!")
+		var/datum/eldritch_knowledge/instantiated_knowledge = new path_to_create()
+		// Next knowledge is a list of typepaths.
+		for(var/datum/eldritch_knowledge/next_knowledge as anything in instantiated_knowledge.next_knowledge)
+			if(!ispath(next_knowledge))
+				Fail("Heretic Knowlege: [next_knowledge.type] has a [isnull(next_knowledge) ? "null":"invalid path"] in its next_knowledge list!")
+				continue
 			if(next_knowledge in list_to_check)
 				continue
 			list_to_check += next_knowledge
 
+		qdel(instantiated_knowledge)
+
+	// We now have a list that SHOULD contain all knowledges with a path set (list_to_check).
+	// Let's compare it to our original list (all_possible_knowledge). If they're not identical,
+	// then somewhere we missed a knowledge somewhere, and should throw a fail.
 	if(length(all_possible_knowledge) != length(all_possible_knowledge & list_to_check))
+		// Unreachables is a list of typepaths - all paths that cannot be obtained.
 		var/list/unreachables = all_possible_knowledge - list_to_check
-		for(var/X in unreachables)
-			var/datum/eldritch_knowledge/eldritch_knowledge = X
-			Fail("[initial(eldritch_knowledge.name)] is unreachable by players! Add it to the blacklist in /code/modules/unit_tests/heretic_knowledge.dm if it is purposeful!")
+		for(var/datum/eldritch_knowledge/lost_knowledge as anything in unreachables)
+			Fail("Heretic Knowlege: [lost_knowledge] is unreachable by players! Add it to another knowledge's 'next_knowledge' list. If it is purposeful, set its route to 'null'.")
+
+
+/*
+ * This test checks that all main heretic paths are of the same length.
+ *
+ * If any two main paths are not equal length, the test will fail and quit, reporting
+ * which two paths did not match. Then, whichever is erroneous can be determined manually.
+ */
+/datum/unit_test/heretic_main_paths
+
+/datum/unit_test/heretic_main_paths/Run()
+	// A list of path strings we don't need to check.
+	var/list/paths_we_dont_check = list(PATH_SIDE, PATH_START)
+	// An assoc list of [path string] to [number of nodes we found of that path].
+	var/list/paths = list()
+	// The starting knowledge node, we use this to deduce what main paths we have.
+	var/datum/eldritch_knowledge/spell/basic/starter_node = new()
+
+	// Go through and determine what paths exist from our base node.
+	for(var/datum/eldritch_knowledge/possible_path as anything in starter_node.next_knowledge)
+		paths[initial(possible_path.route)] = 0
+
+	qdel(starter_node) // Get rid of that starter node, we don't need it anymore.
+
+	// Now go through all the knowledges and record how many of each  main path exist.
+	for(var/datum/eldritch_knowledge/knowledge as anything in subtypesof(/datum/eldritch_knowledge))
+		var/knowledge_route = initial(knowledge.route)
+		// null (abstract), side paths, and start paths we can skip
+		if(isnull(knowledge_route) || (knowledge_route in paths_we_dont_check))
+			continue
+
+		if(isnull(paths[knowledge_route]))
+			Fail("Heretic Knowledge: An invalid knowledge route ([knowledge_route]) was found on [knowledge].")
+			continue
+
+		paths[knowledge_route]++
+
+	// Now all entries in the paths list should have an equal value.
+	// If any two entries do not match, then one of them is incorrect, and the test fails.
+	for(var/main_path in paths)
+		for(var/other_main_path in (paths - main_path))
+			TEST_ASSERT(paths[main_path] == paths[other_main_path], \
+				"Heretic Knowledge: [main_path] had [paths[main_path]] knowledges, \
+				which was not equal to [other_main_path]'s [paths[other_main_path]] knowledges. \
+				All main paths should have the same number of knowledges!")


### PR DESCRIPTION
## Basiaclly https://github.com/The-Merchants-Guild/Merchant-Station-13/pull/296 without all the merge conflicts

## Changelog
:cl: @Salex08 @MrMelbert @ViktorKoL @Watermelon914 @GoblinBackwards
add: Adds a new heretic path, the the Blade Path
expansion: Heretic sidepaths got tweaked a bit. Blood siphon is now between raw ritual and void phase. Cleave is now between Lonely Ritual and Void pull. Rusted Ritual is now between Entropic Plume and Firey Rebirth.
fix: Fixed quite a few bugs and unintended behaviors with heretic code.
refactor: Refactored and improved much of Heretic code. Improved the file structure dramatically.
fix: Rust Heretics now need to stand on Rust to heal again, instead of passive free healing
fix: corrected Fiery Rebirth's and Curse of Corrosion's heretic research descriptions
fix: fixed heretic research progression after unlocking the Lonely Ritual
qol: Heretic now has an antagonist panel
qol: Heretics transmutation rune has a UI now
fix: Rust heretic ascension spread rusts everywhere again.
fix: Ash mark now deals the correct amount of damage and no longer gets stuck bouncing between the same two targets.
balance: Ash mark is significantly stronger due to this fix.
/:cl: